### PR TITLE
ホームタイムライン取得時にcreatedAtではなくidで絞り込むように

### DIFF
--- a/packages/backend/src/misc/id/aid.ts
+++ b/packages/backend/src/misc/id/aid.ts
@@ -6,7 +6,7 @@ import * as crypto from 'node:crypto';
 const TIME2000 = 946684800000;
 let counter = crypto.randomBytes(2).readUInt16LE(0);
 
-function getTime(time: number): string {
+export function getTimeId(time: number): string {
 	time = time - TIME2000;
 	if (time < 0) time = 0;
 
@@ -21,5 +21,5 @@ export function genAid(date: Date): string {
 	const t = date.getTime();
 	if (isNaN(t)) throw 'Failed to create AID: Invalid Date';
 	counter++;
-	return getTime(t) + getNoise();
+	return getTimeId(t) + getNoise();
 }

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -6,6 +6,7 @@ import { QueryService } from '@/core/QueryService.js';
 import ActiveUsersChart from '@/core/chart/charts/active-users.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { getTimeId } from '@/misc/id/aid.js';
 
 export const meta = {
 	tags: ['notes'],
@@ -63,10 +64,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 				.where('following.followerId = :followerId', { followerId: me.id })
 				.getMany();
 
+			const minId = getTimeId(new Date(Date.now() - (1000 * 60 * 60 * 24 * 30)).getTime()) + '00'; // 30日前まで
 			//#region Construct query
 			const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'),
 				ps.sinceId, ps.untilId, ps.sinceDate, ps.untilDate)
-				.andWhere('note.createdAt > :minDate', { minDate: new Date(Date.now() - (1000 * 60 * 60 * 24 * 30)) }) // 30日前まで
+				.andWhere('note.id > :minId', { minId })
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('user.avatar', 'avatar')
 				.leftJoinAndSelect('user.banner', 'banner')


### PR DESCRIPTION
# What
- IDがタイムスタンプベースで生成されていることを利用し、createdAtではなくidで絞り込むように変更

# Why
- createdAtによる絞り込みが結構遅いので

# Additional info (optional)
- ローカルでホームタイムラインが正常に取得できるところまで確認済み
