### PR TITLE
Use limit() instead of take() because take() produces needless DISTINCT

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -131,7 +131,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			}
 			//#endregion
 
-			const timeline = await query.take(ps.limit).getMany();
+			const timeline = await query.limit(ps.limit).getMany();
 
 			process.nextTick(() => {
 				this.activeUsersChart.read(me);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
Home Timeline の構築で用いている `take()` を `limit()` に置き換えます。
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

# Why
クエリパフェーマンスの向上がねらいです。
投稿 note 数の少ないユーザーばかりをフォローしているユーザーにおいて、特に改善幅が大きいです。

複雑な JOIN を含むクエリで take() を用いると、ベーステーブルの行の増幅を避けるために TypeORM が DISTINCT つきのクエリを自動で発行します。
この DISTINCT つきクエリはパフォーマンスへのインパクトが大きく、行の増幅が起きないクエリでは省略すべきです。
現状の Home Timeline のクエリでは行の増幅が起きるような JOIN はしておらず、省略可能です。
明示的に省略する場合は take() ではなく limit() を使います。
参考: https://github.com/typeorm/typeorm/blob/58fc08840a4a64ca1935391f4709a784c3f0b373/docs/select-query-builder.md#using-pagination
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
@Ry0taK 念のためテストしていただけると嬉しいです。直近でこの周辺のクエリを触っていたようなのでセカンドオピニオンとして適切だろうと思ってメンションしています。
<!-- テスト観点など -->
<!-- Test perspective, etc -->
