### PR TITLE
enhance: ダイアログのお知らせにも画像がある場合見せるように

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementDialog.vue
+++ b/packages/frontend/src/components/MkAnnouncementDialog.vue
@@ -15,7 +15,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</span>
 			<Mfm :text="announcement.title"/>
 		</div>
-		<div :class="$style.content"><Mfm :text="announcement.text"/></div>
+		<div :class="$style.content">
+			<Mfm :text="announcement.text"/>
+			<img v-if="announcement.imageUrl" :src="announcement.imageUrl"/>
+		</div>
 		<MkButton :class="$style.gotIt" primary full :disabled="gotItDisabled" @click="gotIt">{{ i18n.ts.gotIt }}<span v-if="secVisible"> ({{ sec }})</span></MkButton>
 	</div>
 </MkModal>
@@ -118,5 +121,10 @@ onMounted(() => {
 
 .content {
 	margin: 1em 0;
+	> img {
+		display: block;
+		max-height: 300px;
+		max-width: 100%;
+	}
 }
 </style>

--- a/packages/frontend/src/pages/announcements.vue
+++ b/packages/frontend/src/pages/announcements.vue
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<div :class="$style.content">
 						<Mfm :text="announcement.text"/>
 						<img v-if="announcement.imageUrl" :src="announcement.imageUrl"/>
-						<div style="opacity: 0.7; font-size: 85%;">
+						<div style="margin-top: 8px; opacity: 0.7; font-size: 85%;">
 							<MkTime :time="announcement.updatedAt ?? announcement.createdAt" mode="detail"/>
 						</div>
 					</div>
@@ -136,7 +136,7 @@ watch(() => $i?.unreadAnnouncements.length ?? 0, () => {
 
 .header {
 	margin-bottom: 16px;
-	font-weight: bold;
+	font-size: 120%;
 }
 
 .content {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

ついでにお知らせの一覧のcssの調整

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
画像で説明が必要なお知らせもダイアログで出したいので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
