### PR TITLE
enhance: シグナルを受け、DB接続が切れたら確実に終了させる

### DIFF
--- a/packages/backend/src/GlobalModule.ts
+++ b/packages/backend/src/GlobalModule.ts
@@ -103,5 +103,6 @@ export class GlobalModule implements OnApplicationShutdown {
 
 	async onApplicationShutdown(signal: string): Promise<void> {
 		await this.dispose();
+		process.emit('exit', 0);
 	}
 }

--- a/packages/backend/src/GlobalModule.ts
+++ b/packages/backend/src/GlobalModule.ts
@@ -4,6 +4,7 @@
  */
 
 import { setTimeout } from 'node:timers/promises';
+import process from 'node:process';
 import { Global, Inject, Module } from '@nestjs/common';
 import * as Redis from 'ioredis';
 import { DataSource } from 'typeorm';
@@ -103,6 +104,9 @@ export class GlobalModule implements OnApplicationShutdown {
 
 	async onApplicationShutdown(signal: string): Promise<void> {
 		await this.dispose();
-		process.emit('exit', 0);
+		process.emitWarning('Misskey is shutting down', {
+			code: 'MISSKEY_SHUTDOWN',
+			detail: `Application received ${signal} signal`,
+		});
 	}
 }

--- a/packages/backend/src/boot/index.ts
+++ b/packages/backend/src/boot/index.ts
@@ -9,7 +9,7 @@
 
 import cluster from 'node:cluster';
 import { EventEmitter } from 'node:events';
-import { exit } from 'node:process';
+import process from 'node:process';
 import chalk from 'chalk';
 import Xev from 'xev';
 import Logger from '@/logger.js';
@@ -79,8 +79,13 @@ process.on('uncaughtException', err => {
 // Dying away...
 process.on('exit', code => {
 	logger.warn(chalk.yellow(`The process is going to exit with code ${code}`));
+});
+
+process.on('warning', warning => {
+	if ((warning as never)['code'] !== 'MISSKEY_SHUTDOWN') return;
+	logger.warn(chalk.yellow(`${warning.message}: ${(warning as never)['detail']}`));
 	for (const id in cluster.workers) cluster.workers[id]?.process.kill('SIGTERM');
-	exit(code);
+	process.exit();
 });
 
 //#endregion

--- a/packages/backend/src/boot/index.ts
+++ b/packages/backend/src/boot/index.ts
@@ -9,6 +9,7 @@
 
 import cluster from 'node:cluster';
 import { EventEmitter } from 'node:events';
+import { exit } from 'node:process';
 import chalk from 'chalk';
 import Xev from 'xev';
 import Logger from '@/logger.js';
@@ -29,6 +30,8 @@ const ev = new Xev();
 
 //#region Events
 
+let isShuttingDown = false;
+
 if (cluster.isPrimary && !envOption.disableClustering) {
 	// Listen new workers
 	cluster.on('fork', worker => {
@@ -41,25 +44,22 @@ if (cluster.isPrimary && !envOption.disableClustering) {
 	});
 
 	// Listen for dying workers
-	cluster.on('exit', (worker, code, signal?) => {
+	cluster.on('exit', (worker, code, signal) => {
 		// Replace the dead worker,
 		// we're not sentimental
-		if (signal) {
-			switch (signal) {
-				case 'SIGINT':
-				case 'SIGTERM':
-					console.log(chalk.green(`[${worker.id}] exited by signal: ${signal}`));
-					break;
-				default:
-					console.error(chalk.red(`[${worker.id}] killed by signal: ${signal}`));
-					cluster.fork();
-					break;
-			}
-		} else if (code !== 0) {
-			console.error(chalk.red(`[${worker.id}] exited with error code: ${code}`));
-		} else {
-			console.log(chalk.green(`[${worker.id}] exited normally`));
-		}
+		clusterLogger.error(chalk.red(`[${worker.id}] died (${signal || code})`));
+		if (!isShuttingDown) cluster.fork();
+		else clusterLogger.info(chalk.yellow('Worker respawn disabled because of shutdown'));
+	});
+
+	process.on('SIGINT', () => {
+		logger.warn(chalk.yellow('Process received SIGINT'));
+		isShuttingDown = true;
+	});
+
+	process.on('SIGTERM', () => {
+		logger.warn(chalk.yellow('Process received SIGTERM'));
+		isShuttingDown = true;
 	});
 }
 
@@ -78,7 +78,9 @@ process.on('uncaughtException', err => {
 
 // Dying away...
 process.on('exit', code => {
-	logger.info(`The process is going to exit with code ${code}`);
+	logger.warn(chalk.yellow(`The process is going to exit with code ${code}`));
+	for (const id in cluster.workers) cluster.workers[id]?.process.kill('SIGTERM');
+	exit(code);
 });
 
 //#endregion


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
まだプライマリープロセスが終わらないことがある
DB接続が切れたら何もできるはずがないので、確実に終了するようにイベントを呼ぶ

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
nestjsがおかしいかも
裏は全く取れてないけど個人的にはQueueProcessorServiceが怪しい
（Masterでは使われないのでそもそも呼び出されないが、handlerはあるのでこれが終わるのを待ってるとか？）

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
タスクマネージャからプライマリープロセスを終了させようとすると反応しないのが直った
プライマリープロセスがシャットダウン中のみワーカープロセスが再起動しないようにした

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
