### PR TITLE
Extend slow query threshold to reduce logs

### DIFF
--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -240,7 +240,7 @@ export function createPostgresDataSource(config: Config) {
 		} : false,
 		logging: log,
 		logger: log ? new MyCustomLogger() : undefined,
-		maxQueryExecutionTime: 300,
+		maxQueryExecutionTime: 10000, // 10s
 		entities: entities,
 		migrations: ['../../migration/*.js'],
 	});


### PR DESCRIPTION
## What
クエリが slow であると判定される閾値を 300ms から 10s に伸ばします。

## Why
300ms を閾値とすると、あまりに多くのクエリが slow 判定され、あまりに多くの slow query log が出力されてしまい、パフォーマンス分析の際にノイズになるため。
io では pg_stat_statements 等を用いて slow query を分析できるため、アプリケーションレベルで閾値の厳しいログを吐く意味はない。
