### PR TITLE
サーバーから切断された後 stream indicator をすぐに表示しないようにする

### DIFF
--- a/packages/frontend/src/ui/_common_/stream-indicator.vue
+++ b/packages/frontend/src/ui/_common_/stream-indicator.vue
@@ -24,12 +24,17 @@ import { defaultStore } from '@/store';
 const zIndex = os.claimZIndex('high');
 
 let hasDisconnected = $ref(false);
+let timeoutId = $ref<number>();
 
 function onDisconnected() {
-	hasDisconnected = true;
+	window.clearTimeout(timeoutId);
+	timeoutId = window.setTimeout(() => {
+		hasDisconnected = true;
+	}, 1000 * 10);
 }
 
 function resetDisconnected() {
+	window.clearTimeout(timeoutId);
 	hasDisconnected = false;
 }
 
@@ -37,9 +42,12 @@ function reload() {
 	location.reload();
 }
 
+useStream().on('_connected_', resetDisconnected);
 useStream().on('_disconnected_', onDisconnected);
 
 onUnmounted(() => {
+	window.clearTimeout(timeoutId);
+	useStream().off('_connected_', resetDisconnected);
 	useStream().off('_disconnected_', onDisconnected);
 });
 </script>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
stream indicator を切断されてすぐ表示しないように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
