### PR TITLE
Hot-fix: Write-back value in memory when it's available in redis

### DIFF
--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -150,6 +150,7 @@ export class RedisSingleCache<T> {
 		const cached = await this.redisClient.get(`singlecache:${this.name}`);
 		if (cached == null) return undefined;
 		const parsed = this.fromRedisConverter(cached);
+    if (parsed == null) return undefined;
 		this.memoryCache.set(parsed);
 		return parsed;
 	}

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -166,6 +166,7 @@ export class RedisSingleCache<T> {
 		const cachedValue = await this.get();
 		if (cachedValue !== undefined) {
 			// Cache HIT
+      this.memoryCache.set(cachedValue);
 			return cachedValue;
 		}
 

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -149,7 +149,9 @@ export class RedisSingleCache<T> {
 
 		const cached = await this.redisClient.get(`singlecache:${this.name}`);
 		if (cached == null) return undefined;
-		return this.fromRedisConverter(cached);
+		const parsed = this.fromRedisConverter(cached);
+		this.memoryCache.set(parsed);
+		return parsed;
 	}
 
 	@bindThis
@@ -166,7 +168,6 @@ export class RedisSingleCache<T> {
 		const cachedValue = await this.get();
 		if (cachedValue !== undefined) {
 			// Cache HIT
-      this.memoryCache.set(cachedValue);
 			return cachedValue;
 		}
 


### PR DESCRIPTION
## What
Memory 上の lifetime(TTL) は切れたが、Redis 上の lifetime はまだ切れていないという状況で、Redis から読み取った値を MemoryCache に書き戻します。

## Why
現状、Redis + MemoryCache の2層キャッシュである RedisSingleCache において、MemoryCache 上の lifetime(TTL) は切れたが、Redis 上の lifetime はまだ切れていないという状況で、都度 Redis へのリクエストと Redis からのレスポンスのパースが走ってしまいます。
（つまり、MemoryCache が仕事をしなくなってしまう）
この影響で、CustomEmojiService ではキャッシュを書いた3分後からの27([=30-3](https://github.com/MisskeyIO/misskey/blob/760fe8cfcc4e08d05d7e4501219c3638fa56d3a1/packages/backend/src/core/CustomEmojiService.ts#L51-L52))分間は Redis へのクエリと JSON.parse が大爆発するボーナスタイムになっています。
このパッチはこれを解決します。

## Additional info (optional)
Redis 上での残り lifetime を考慮せずに MemoryCache に書き戻してしまうため、実際の lifetime が lifetime + memoryCacheLifetime となります。
たとえば CustomEmojiService では従来30分間の lifetime だったところ、このパッチの影響で33分間キャッシュされることになります。
