### PR TITLE
fix(backend): プロフィールの自己紹介欄のMFMを連合するように (misskey-dev#12184)

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -496,6 +496,7 @@ export class ApRendererService {
 			preferredUsername: user.username,
 			name: user.name,
 			summary: profile.description ? this.mfmService.toHtml(mfm.parse(profile.description)) : null,
+			_misskey_summary: profile.description,
 			icon: avatar ? this.renderImage(avatar) : null,
 			image: banner ? this.renderImage(banner) : null,
 			tag,
@@ -645,6 +646,7 @@ export class ApRendererService {
 					'_misskey_quote': 'misskey:_misskey_quote',
 					'_misskey_reaction': 'misskey:_misskey_reaction',
 					'_misskey_votes': 'misskey:_misskey_votes',
+					'_misskey_summary': 'misskey:_misskey_summary',
 					'isCat': 'misskey:isCat',
 					// vcard
 					vcard: 'http://www.w3.org/2006/vcard/ns#',

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -337,7 +337,7 @@ export class ApPersonService implements OnModuleInit {
 
 				await transactionalEntityManager.save(new MiUserProfile({
 					userId: user.id,
-					description: person.summary ? this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag) : null,
+					description: person._misskey_summary ? truncate(person._misskey_summary, summaryLength) : person.summary ? this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag) : null,
 					url,
 					fields,
 					birthday: bday?.[0] ?? null,

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -511,10 +511,18 @@ export class ApPersonService implements OnModuleInit {
 			});
 		}
 
+		let _description: string | null = null;
+
+		if (person._misskey_summary) {
+			_description = truncate(person._misskey_summary, summaryLength);
+		} else if (person.summary) {
+			_description = this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag);
+		}
+
 		await this.userProfilesRepository.update({ userId: exist.id }, {
 			url,
 			fields,
-			description: person.summary ? this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag) : null,
+			description: _description,
 			birthday: bday?.[0] ?? null,
 			location: person['vcard:Address'] ?? null,
 		});

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -335,9 +335,17 @@ export class ApPersonService implements OnModuleInit {
 					emojis,
 				})) as MiRemoteUser;
 
+				let _description: string | null = null;
+
+				if (person._misskey_summary) {
+					_description = truncate(person._misskey_summary, summaryLength)
+				} else if (person.summary) {
+					_description = this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag);
+				}
+
 				await transactionalEntityManager.save(new MiUserProfile({
 					userId: user.id,
-					description: person._misskey_summary ? truncate(person._misskey_summary, summaryLength) : person.summary ? this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag) : null,
+					description: _description,
 					url,
 					fields,
 					birthday: bday?.[0] ?? null,

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -338,7 +338,7 @@ export class ApPersonService implements OnModuleInit {
 				let _description: string | null = null;
 
 				if (person._misskey_summary) {
-					_description = truncate(person._misskey_summary, summaryLength)
+					_description = truncate(person._misskey_summary, summaryLength);
 				} else if (person.summary) {
 					_description = this.apMfmService.htmlToMfm(truncate(person.summary, summaryLength), person.tag);
 				}

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -12,6 +12,7 @@ export interface IObject {
 	id?: string;
 	name?: string | null;
 	summary?: string;
+	_misskey_summary?: string;
 	published?: string;
 	cc?: ApObject;
 	to?: ApObject;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
プロフのMFMを連合するようになる

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
本家にマージされてしまった＆コードを見た感じ動きそうだったので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
misskey-dev#12184
misskey-dev#12185

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
