### PR TITLE
enhance(frontend): 絵文字ピッカーで長いカテゴリの名前を前の部分から省略して表示するように

### DIFF
--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -615,11 +615,17 @@ defineExpose({
 				position: sticky;
 				top: 0;
 				left: 0;
-				line-height: 28px;
+				height: 32px;
+				line-height: 32px;
 				z-index: 1;
 				padding: 0 8px;
 				font-size: 12px;
 				cursor: pointer;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				direction: rtl;
+				text-align: left;
 
 				&:hover {
 					color: var(--accent);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
とても長い絵文字のカテゴリの名前が
「とてもながいえもじのかてごりのなまえ」から
「…かてごりのなまえ」になる（ウィンドウの幅による）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リスト内に前の部分が同じ文字列がめちゃくちゃ並ぶので省略しちゃったほうが分かりやすいのではと思ったため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
~~スマホ編集なのでテストできてない~~
![image](https://github.com/MisskeyIO/misskey/assets/17376330/51d8f74b-9538-4c23-9bf3-d805339214d1)
期待通りの挙動をしてた

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
