### PR TITLE
fix(frontend): モバイル環境でタイムラインの上段メニューに空のボタンが追加されている問題を修正

### DIFF
--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -122,13 +122,14 @@ function focus(): void {
 	tlComponent.focus();
 }
 
-const headerActions = $computed(() => [
-	...[deviceKind === 'desktop' ? {
+const headerActions = $computed(() => deviceKind === 'desktop'
+	? [{
 		icon: 'ti ti-refresh',
 		text: i18n.ts.reload,
 		handler: () => { tlComponent.reloadTimeline(); },
-	} : {}],
-]);
+	}]
+	: []
+);
 
 const headerTabs = $computed(() => [{
 	key: 'home',


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
モバイル環境でタイムラインの上段メニューに空のボタンが追加されている問題を修正
デスクトップ環境用のリロードボタンの代わりに空のobjectを渡してしまっているため空のボタンが登録されていた

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
