### PR TITLE
enhance(frontend/PullToRefresh): コンポーネントがDOMから消えた時点でタッチ操作などのコールバック関数が止まるように

### DIFF
--- a/packages/frontend/src/components/MkPullToRefresh.vue
+++ b/packages/frontend/src/components/MkPullToRefresh.vue
@@ -24,8 +24,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import MkLoading from '@/components/global/MkLoading.vue';
-import { i18n } from '@/i18n.js';
 import { onMounted, onUnmounted, onActivated, onDeactivated } from 'vue';
+import { i18n } from '@/i18n.js';
 import { getScrollContainer } from '@/scripts/scroll.js';
 
 const SCROLL_STOP = 10;

--- a/packages/frontend/src/components/MkPullToRefresh.vue
+++ b/packages/frontend/src/components/MkPullToRefresh.vue
@@ -24,9 +24,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import MkLoading from '@/components/global/MkLoading.vue';
-import { onMounted, onUnmounted, watch } from 'vue';
-import { deviceKind } from '@/scripts/device-kind.js';
 import { i18n } from '@/i18n.js';
+import { onMounted, onUnmounted, onActivated, onDeactivated } from 'vue';
 import { getScrollContainer } from '@/scripts/scroll.js';
 
 const SCROLL_STOP = 10;
@@ -197,6 +196,7 @@ function onScrollContainerScroll() {
 }
 
 onMounted(() => {
+	isRefreshing = false;
 	if (rootEl == null) return;
 	scrollEl = getScrollContainer(rootEl);
 	if (scrollEl == null) return;
@@ -206,7 +206,18 @@ onMounted(() => {
 	rootEl.addEventListener('touchend', moveEnd, { passive: true });
 });
 
+onActivated(() => {
+	isRefreshing = false;
+});
+
+onDeactivated(() => {
+	scrollEl!.style.touchAction = 'auto';
+	isRefreshing = true;
+});
+
 onUnmounted(() => {
+	scrollEl!.style.touchAction = 'auto';
+	isRefreshing = true;
 	if (scrollEl) scrollEl.removeEventListener('scroll', onScrollContainerScroll);
 	if (rootEl == null) return;
 	rootEl.removeEventListener('touchstart', moveStart);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
たまにTL画面からユーザープロフィール画面に移動した時上方向のタッチ操作ができなくなる問題を修正（したい）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
なぜか後ろにあるはずのMkPullToRefreshのhandlerが動いて邪魔になっていると思うので
onDeactivatedもしくはonUnmountedイベント発生時に更新中フラグを立てて何もしないようにする

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
