### PR TITLE
fix(frontend): ユーザーページのファイル一覧のセンシティブとして設定されたファイルの表示がおかしい問題を修正

### DIFF
--- a/packages/frontend/src/pages/user/index.files.vue
+++ b/packages/frontend/src/pages/user/index.files.vue
@@ -13,8 +13,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<template v-for="file in files" :key="file.note.id + file.file.id">
 				<div v-if="file.file.isSensitive && !showingFiles.includes(file.file.id)" :class="$style.sensitive" @click="showingFiles.push(file.file.id)">
 					<div>
-						<div><i class="ti ti-eye-exclamation"></i> {{ i18n.ts.sensitive }}</div>
-						<div>{{ i18n.ts.clickToShow }}</div>
+						<b style="display: block;"><i class="ti ti-eye-exclamation"/> {{ i18n.ts.sensitive }}</b>
+						<span style="display: block;">{{ i18n.ts.clickToShow }}</span>
 					</div>
 				</div>
 				<MkA v-else :class="$style.img" :to="notePage(file.note)">
@@ -100,7 +100,15 @@ onMounted(() => {
 }
 
 .sensitive {
-	display: grid;
-  place-items: center;
+	width: 100%;
+	height: 128px;
+	display: flex;
+	font-size: 0.8em;
+	text-align: center;
+	align-items: center;
+	justify-content: center;
+	color: #fff;
+	background-color: rgba(0, 0, 0, 0.5);
+	border-radius: 6px;
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

![image](https://github.com/MisskeyIO/misskey/assets/17376330/f3d650cc-1f80-40cf-b911-c2519052f9e4)
これを
![image](https://github.com/MisskeyIO/misskey/assets/17376330/ab95fbb8-1af4-44f0-a2f3-6d7fd617853e)
こんな風に

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->


## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
cc: @syuilo 

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
