### PR TITLE
fix(EmojiPicker): 投稿フォームで絵文字ボタンを押すと従来通り絵文字ピッカーのウィンドウが開くように

### DIFF
--- a/packages/frontend/src/components/MkEmojiPickerWindow.vue
+++ b/packages/frontend/src/components/MkEmojiPickerWindow.vue
@@ -13,18 +13,25 @@ SPDX-License-Identifier: AGPL-3.0-only
 	:front="true"
 	@closed="emit('closed')"
 >
-	<MkEmojiPicker :showPinned="showPinned" :asReactionPicker="asReactionPicker" asWindow :class="$style.picker" @chosen="chosen"/>
+	<MkEmojiPicker
+		:class="$style.picker"
+		:showPinned="showPinned"
+		:pinnedEmojis="pinnedEmojis"
+		:asReactionPicker="asReactionPicker"
+		asWindow
+		@chosen="chosen"
+	/>
 </MkWindow>
 </template>
 
 <script lang="ts" setup>
-import { } from 'vue';
 import MkWindow from '@/components/MkWindow.vue';
 import MkEmojiPicker from '@/components/MkEmojiPicker.vue';
 
 withDefaults(defineProps<{
 	src?: HTMLElement;
 	showPinned?: boolean;
+	pinnedEmojis?: string[],
 	asReactionPicker?: boolean;
 }>(), {
 	showPinned: true,

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -860,15 +860,10 @@ function insertMention() {
 async function insertEmoji(ev: MouseEvent) {
 	textAreaReadOnly.value = true;
 
-	emojiPicker.show(
-		ev.currentTarget ?? ev.target,
-		emoji => {
-			insertTextAtCursor(textareaEl.value, emoji);
-		},
-		() => {
-			textAreaReadOnly.value = false;
-			nextTick(() => focus());
-		},
+	os.openEmojiPicker(
+		(ev.currentTarget ?? ev.target) as HTMLElement,
+		{ asReactionPicker: false },
+		textareaEl.value
 	);
 }
 

--- a/packages/frontend/src/os.ts
+++ b/packages/frontend/src/os.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from 'eventemitter3';
 import insertTextAtCursor from 'insert-text-at-cursor';
 import * as Misskey from 'misskey-js';
 import { i18n } from '@/i18n.js';
+import { defaultStore } from '@/store.js';
 import MkPostFormDialog from '@/components/MkPostFormDialog.vue';
 import MkWaitingDialog from '@/components/MkWaitingDialog.vue';
 import MkPageWindow from '@/components/MkPageWindow.vue';
@@ -533,6 +534,7 @@ export async function openEmojiPicker(src?: HTMLElement, opts, initialTextarea: 
 
 	openingEmojiPicker = await popup(MkEmojiPickerWindow, {
 		src,
+		pinnedEmojis: opts?.asReactionPicker ? defaultStore.reactiveState.reactions : defaultStore.reactiveState.pinnedEmojis,
 		...opts,
 	}, {
 		chosen: emoji => {

--- a/packages/frontend/src/pages/admin/announcements.vue
+++ b/packages/frontend/src/pages/admin/announcements.vue
@@ -131,7 +131,11 @@ function editUser(announcement): void {
 }
 
 function insertEmoji(ev: MouseEvent): void {
-	os.openEmojiPicker((ev.currentTarget ?? ev.target) as HTMLElement, {}, announceTitleEl.value);
+	os.openEmojiPicker(
+		(ev.currentTarget ?? ev.target) as HTMLElement,
+		{ asReactionPicker: false },
+		announceTitleEl.value
+	);
 }
 
 function add() {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
投稿フォームで絵文字ボタンを押すと従来通り絵文字ピッカーのウィンドウが開くように
お知らせの絵文字ボタンでも同じ挙動になるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
ioモデレーションチーム要請

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
