### PR TITLE
fix(Queue): InboxやDeliverキューにdataフィールドが空のジョブが登録されないように

### DIFF
--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -116,7 +116,7 @@ export class QueueService {
 
 		await this.deliverQueue.addBulk(Array.from(inboxes.entries(), d => ({
 			name: d[0],
-			data: <DeliverJobData> {
+			data: {
 				user,
 				content,
 				to: d[0],

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -116,12 +116,12 @@ export class QueueService {
 
 		await this.deliverQueue.addBulk(Array.from(inboxes.entries(), d => ({
 			name: d[0],
-			data: {
+			data: <DeliverJobData> {
 				user,
 				content,
 				to: d[0],
 				isSharedInbox: d[1],
-			} as DeliverJobData,
+			},
 			opts,
 		})));
 

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -162,7 +162,13 @@ export class ActivityPubServerService {
 			}
 		}
 
-		this.queueService.inbox(request.body as IActivity, signature);
+		const activity = request.body as IActivity;
+		if (!activity.type || !signature.keyId) {
+			reply.code(400);
+			return;
+		}
+
+		this.queueService.inbox(activity, signature);
 
 		reply.code(202);
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`as タイプ`の結果をそのまま渡すのではなくチェックを入れたりをもそも`as`を使わないようにした

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
queueにdataフィールドが空のジョブが登録され、ずっとエラーになるため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
