### PR TITLE
Docker イメージビルド時の pnpm i 後に pnpm rebuild を実行するように

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /misskey
 
 COPY --link pnpm-lock.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
-	pnpm fetch
+	pnpm fetch --ignore-scripts
 
 COPY --link ["pnpm-workspace.yaml", "package.json", "./"]
 COPY --link ["scripts", "./scripts"]
@@ -29,7 +29,8 @@ COPY --link ["packages/frontend/package.json", "./packages/frontend/"]
 COPY --link ["packages/sw/package.json", "./packages/sw/"]
 COPY --link ["packages/misskey-js/package.json", "./packages/misskey-js/"]
 
-RUN pnpm i --frozen-lockfile --aggregate-output --offline
+RUN pnpm i --frozen-lockfile --aggregate-output --offline \
+	&& pnpm rebuild -r
 
 COPY --link . ./
 
@@ -53,14 +54,15 @@ WORKDIR /misskey
 
 COPY --link pnpm-lock.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
-	pnpm fetch
+	pnpm fetch --ignore-scripts
 
 COPY --link ["pnpm-workspace.yaml", "package.json", "./"]
 COPY --link ["scripts", "./scripts"]
 COPY --link ["packages/backend/package.json", "./packages/backend/"]
 COPY --link ["packages/misskey-js/package.json", "./packages/misskey-js/"]
 
-RUN pnpm i --frozen-lockfile --aggregate-output --offline
+RUN pnpm i --frozen-lockfile --aggregate-output --offline \
+	&& pnpm rebuild -r
 
 FROM --platform=$TARGETPLATFORM node:${NODE_VERSION}-slim AS runner
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Docker イメージビルド時の pnpm i 後に pnpm rebuild を実行するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
各依存関係の postinstall 等が走るステージが native-builder と target-builder のどちらか(タイミング次第)であり、native-builder のみで走った場合に一部の機能が動かないため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Closes MisskeyIO#316

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
