### PR TITLE
Remove "process" queue stat counter for performance

### DIFF
--- a/packages/backend/src/boot/common.ts
+++ b/packages/backend/src/boot/common.ts
@@ -24,7 +24,7 @@ export async function server() {
 
 	if (process.env.NODE_ENV !== 'test') {
 		app.get(ChartManagementService).start();
-		// app.get(QueueStatsService).start();
+		app.get(QueueStatsService).start();
 		// app.get(ServerStatsService).start();
 	}
 

--- a/packages/backend/src/boot/common.ts
+++ b/packages/backend/src/boot/common.ts
@@ -9,7 +9,6 @@ import { QueueProcessorService } from '@/queue/QueueProcessorService.js';
 import { NestLogger } from '@/NestLogger.js';
 import { QueueProcessorModule } from '@/queue/QueueProcessorModule.js';
 import { QueueStatsService } from '@/daemons/QueueStatsService.js';
-import { ServerStatsService } from '@/daemons/ServerStatsService.js';
 import { ServerService } from '@/server/ServerService.js';
 import { MainModule } from '@/MainModule.js';
 
@@ -25,7 +24,6 @@ export async function server() {
 	if (process.env.NODE_ENV !== 'test') {
 		app.get(ChartManagementService).start();
 		app.get(QueueStatsService).start();
-		// app.get(ServerStatsService).start();
 	}
 
 	return app;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
- Queue Stats の数字が "Process" 以外もとに戻ります

<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
- Queue Stats の数字はほしい
  - "Process" の数字を計算するには Redis Streams を subscribe する必要がある
  - パフォーマンスインパクトが大きすぎる
- "Process" は0で固定し、それ以外を復活させる

<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
