### PR TITLE
fix: MK_LOG_JSONのcontextの値が正常に表示されない問題を修正

### DIFF
--- a/packages/backend/src/logger.ts
+++ b/packages/backend/src/logger.ts
@@ -57,7 +57,7 @@ export default class Logger {
 				message: message,
 				data: data,
 				important: important,
-				context: [this.context].concat(subContexts).join('.'),
+				context: [this.context].concat(subContexts).map(d => d.name).join('.'),
 				cluster: cluster.isPrimary ? 'primary' : `worker-${cluster.worker!.id}`,
 			}));
 			return;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix bug from MisskeyIO#346

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`context`の値が`[object Object].[object Object]`と出てしまっているため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
