### PR TITLE
fix(drop-and-fusion): バブルゲームのリトライボタンでリトライができない問題を修正

### DIFF
--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -153,7 +153,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</div>
 			<div :class="$style.frame">
 				<div :class="$style.frameInner">
-					<MkButton danger @click="surrender">Retry</MkButton>
+					<MkButton v-if="!isGameOver && !replaying" full danger @click="surrender">Surrender</MkButton>
+					<MkButton v-else full @click="retry">Retry</MkButton>
 				</div>
 			</div>
 		</div>
@@ -483,15 +484,22 @@ async function surrender() {
 	game.surrender();
 }
 
+async function retry() {
+	end();
+	await start();
+}
+
 function end() {
 	game.dispose();
 	isGameOver.value = false;
+	replaying.value = false;
 	currentPick.value = null;
 	dropReady.value = true;
 	stock.value = [];
 	score.value = 0;
 	combo.value = 0;
 	comboPrev.value = 0;
+	maxCombo.value = 0;
 	bgmNodes?.soundSource.stop();
 	gameStarted.value = false;
 }

--- a/packages/frontend/src/scripts/drop-and-fusion-engine.ts
+++ b/packages/frontend/src/scripts/drop-and-fusion-engine.ts
@@ -500,12 +500,13 @@ export class DropAndFusionGame extends EventEmitter<{
 		});
 		this.emit('changeStock', this.stock);
 
-		const x = Math.min(this.gameWidth - this.PLAYAREA_MARGIN - (head.mono.size / 2), Math.max(this.PLAYAREA_MARGIN + (head.mono.size / 2), Math.round(_x)));
+		const inputX = Math.round(_x);
+		const x = Math.min(this.gameWidth - this.PLAYAREA_MARGIN - (head.mono.size / 2), Math.max(this.PLAYAREA_MARGIN + (head.mono.size / 2), inputX));
 		const body = this.createBody(head.mono, x, 50 + head.mono.size / 2);
 		this.logs.push({
 			frame: this.frame,
 			operation: 'drop',
-			x,
+			x: inputX,
 		});
 		Matter.Composite.add(this.engine.world, body);
 		this.activeBodyIds.push(body.id);


### PR DESCRIPTION
本家の更新のコミットもついでに入れた

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ゲーム中なら諦める、ゲームオーバー画面の表示中はリスタートになるように
一部の値がゲーム終了時初期化されていないのも直した

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リトライって書いてあるにもかかわらずリトライができないボタンになっていたので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
cc: @syuilo 

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
