### PR TITLE
spec(ActivityPub): 個別ユーザーのinboxに届いた限定公開のPostはそのユーザーに閲覧権限があると見なす

### DIFF
--- a/packages/backend/src/core/PollService.ts
+++ b/packages/backend/src/core/PollService.ts
@@ -97,7 +97,7 @@ export class PollService {
 		if (note.localOnly) return;
 
 		const user = await this.usersRepository.findOneBy({ id: note.userId });
-		if (user == null) throw new Error('note not found');
+		if (user == null) throw new Error('user not found');
 
 		if (this.userEntityService.isLocalUser(user)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUpdate(await this.apRendererService.renderNote(note, false), user));

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -137,8 +137,9 @@ export class QueueService {
 	}
 
 	@bindThis
-	public inbox(activity: IActivity, signature: httpSignature.IParsedSignature) {
+	public inbox(user: ThinUser | null, activity: IActivity, signature: httpSignature.IParsedSignature) {
 		const data = {
+			user: user ?? undefined,
 			activity: activity,
 			signature,
 		};

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -26,7 +26,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { QueueService } from '@/core/QueueService.js';
 import type { UsersRepository, NotesRepository, FollowingsRepository, AbuseUserReportsRepository, FollowRequestsRepository } from '@/models/_.js';
 import { bindThis } from '@/decorators.js';
-import type { MiRemoteUser } from '@/models/User.js';
+import type { MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import { getApHrefNullable, getApId, getApIds, getApType, isAccept, isActor, isAdd, isAnnounce, isBlock, isCollection, isCollectionOrOrderedCollection, isCreate, isDelete, isFlag, isFollow, isLike, isMove, isPost, isReject, isRemove, isTombstone, isUndo, isUpdate, validActor, validPost } from './type.js';
 import { ApNoteService } from './models/ApNoteService.js';
 import { ApLoggerService } from './ApLoggerService.js';
@@ -87,13 +87,13 @@ export class ApInboxService {
 	}
 
 	@bindThis
-	public async performActivity(actor: MiRemoteUser, activity: IObject): Promise<void> {
+	public async performActivity(actor: MiRemoteUser, activity: IObject, additionalTo?: MiLocalUser['id']): Promise<void> {
 		if (isCollectionOrOrderedCollection(activity)) {
 			const resolver = this.apResolverService.createResolver();
 			for (const item of toArray(isCollection(activity) ? activity.items : activity.orderedItems)) {
 				const act = await resolver.resolve(item);
 				try {
-					await this.performOneActivity(actor, act);
+					await this.performOneActivity(actor, act, additionalTo);
 				} catch (err) {
 					if (err instanceof Error || typeof err === 'string') {
 						this.logger.error(err);
@@ -103,7 +103,7 @@ export class ApInboxService {
 				}
 			}
 		} else {
-			await this.performOneActivity(actor, activity);
+			await this.performOneActivity(actor, activity, additionalTo);
 		}
 
 		// ついでにリモートユーザーの情報が古かったら更新しておく
@@ -117,15 +117,15 @@ export class ApInboxService {
 	}
 
 	@bindThis
-	public async performOneActivity(actor: MiRemoteUser, activity: IObject): Promise<void> {
+	public async performOneActivity(actor: MiRemoteUser, activity: IObject, additionalTo?: MiLocalUser['id']): Promise<void> {
 		if (actor.isSuspended) return;
 
 		if (isCreate(activity)) {
-			await this.create(actor, activity);
+			await this.create(actor, activity, additionalTo);
 		} else if (isDelete(activity)) {
 			await this.delete(actor, activity);
 		} else if (isUpdate(activity)) {
-			await this.update(actor, activity);
+			await this.update(actor, activity, additionalTo);
 		} else if (isFollow(activity)) {
 			await this.follow(actor, activity);
 		} else if (isAccept(activity)) {
@@ -346,7 +346,7 @@ export class ApInboxService {
 	}
 
 	@bindThis
-	private async create(actor: MiRemoteUser, activity: ICreate): Promise<void> {
+	private async create(actor: MiRemoteUser, activity: ICreate, additionalTo?: MiLocalUser['id']): Promise<void> {
 		const uri = getApId(activity);
 
 		this.logger.info(`Create: ${uri}`);
@@ -375,14 +375,14 @@ export class ApInboxService {
 		});
 
 		if (isPost(object)) {
-			await this.createNote(resolver, actor, object, false, activity);
+			await this.createNote(resolver, actor, object, false, activity, additionalTo);
 		} else {
 			this.logger.warn(`Unknown type: ${getApType(object)}`);
 		}
 	}
 
 	@bindThis
-	private async createNote(resolver: Resolver, actor: MiRemoteUser, note: IObject, silent = false, activity?: ICreate): Promise<string> {
+	private async createNote(resolver: Resolver, actor: MiRemoteUser, note: IObject, silent = false, activity?: ICreate, additionalTo?: MiLocalUser['id']): Promise<string> {
 		const uri = getApId(note);
 
 		if (typeof note === 'object') {
@@ -401,9 +401,14 @@ export class ApInboxService {
 
 		try {
 			const exist = await this.apNoteService.fetchNote(note);
-			if (exist) return 'skip: note exists';
+			if (additionalTo && exist && !await this.noteEntityService.isVisibleForMe(exist, additionalTo)) {
+				await this.noteCreateService.appendNoteVisibleUser(actor, exist, additionalTo);
+				return 'ok: note visible user appended';
+			} else if (exist) {
+				return 'skip: note exists';
+			}
 
-			await this.apNoteService.createNote(note, resolver, silent);
+			await this.apNoteService.createNote(note, resolver, silent, additionalTo);
 			return 'ok';
 		} catch (err) {
 			if (err instanceof StatusError && !err.isRetryable) {
@@ -731,7 +736,7 @@ export class ApInboxService {
 	}
 
 	@bindThis
-	private async update(actor: MiRemoteUser, activity: IUpdate): Promise<string> {
+	private async update(actor: MiRemoteUser, activity: IUpdate, additionalTo?: MiLocalUser['id']): Promise<string> {
 		if (actor.uri !== activity.actor) {
 			return 'skip: invalid actor';
 		}
@@ -751,6 +756,27 @@ export class ApInboxService {
 		} else if (getApType(object) === 'Question') {
 			await this.apQuestionService.updateQuestion(object, resolver).catch(err => this.logger.error(`err: failed to update question: ${err}`, { error: err }));
 			return 'ok: Question updated';
+		} else if (additionalTo && isPost(object)) {
+			const uri = getApId(object);
+			const unlock = await this.appLockService.getApLock(uri);
+
+			try {
+				const exist = await this.apNoteService.fetchNote(object);
+				if (exist && !await this.noteEntityService.isVisibleForMe(exist, additionalTo)) {
+					await this.noteCreateService.appendNoteVisibleUser(actor, exist, additionalTo);
+					return 'ok: note visible user appended';
+				} else {
+					return 'skip: nothing to do';
+				}
+			} catch (err) {
+				if (err instanceof StatusError && !err.isRetryable) {
+					return `skip ${err.statusCode}`;
+				} else {
+					throw err;
+				}
+			} finally {
+				unlock();
+			}
 		} else {
 			return `skip: Unknown type: ${getApType(object)}`;
 		}

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -180,7 +180,7 @@ export class InboxProcessorService {
 		});
 
 		// アクティビティを処理
-		await this.apInboxService.performActivity(authUser.user, activity);
+		await this.apInboxService.performActivity(authUser.user, activity, job.data.user?.id);
 		return 'ok';
 	}
 }

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -26,6 +26,7 @@ export type DeliverJobData = {
 };
 
 export type InboxJobData = {
+	user?: ThinUser;
 	activity: IActivity;
 	signature: httpSignature.IParsedSignature;
 };

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -100,8 +100,8 @@ export class ActivityPubServerService {
 	}
 
 	@bindThis
-	private async inbox(request: FastifyRequest<{ Params: { user?: string; }; }>, reply: FastifyReply) {
-		const userId = request.params.user;
+	private async inbox(request: FastifyRequest, reply: FastifyReply) {
+		const userId = (request.params as { user: string; } | undefined)?.user;
 		let signature;
 
 		try {
@@ -562,7 +562,7 @@ export class ActivityPubServerService {
 
 		//#region Routing
 		// inbox (limit: 64kb)
-		fastify.post<{ Params: { }; }>('/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
+		fastify.post('/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
 		fastify.post<{ Params: { user: string; }; }>('/users/:user/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
 
 		// note

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -100,7 +100,8 @@ export class ActivityPubServerService {
 	}
 
 	@bindThis
-	private inbox(request: FastifyRequest, reply: FastifyReply) {
+	private async inbox(request: FastifyRequest<{ Params: { user?: string; }; }>, reply: FastifyReply) {
+		const userId = request.params.user;
 		let signature;
 
 		try {
@@ -162,14 +163,23 @@ export class ActivityPubServerService {
 			}
 		}
 
+		const user = userId ? await this.usersRepository.findOneBy({
+			id: userId,
+			host: IsNull(),
+		}) : null;
+
+		if (userId && user == null) {
+			reply.code(404);
+			return;
+		}
+
 		const activity = request.body as IActivity;
 		if (!activity.type || !signature.keyId) {
 			reply.code(400);
 			return;
 		}
 
-		this.queueService.inbox(activity, signature);
-
+		await this.queueService.inbox(user, activity, signature);
 		reply.code(202);
 	}
 
@@ -552,8 +562,8 @@ export class ActivityPubServerService {
 
 		//#region Routing
 		// inbox (limit: 64kb)
-		fastify.post('/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
-		fastify.post('/users/:user/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
+		fastify.post<{ Params: { }; }>('/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
+		fastify.post<{ Params: { user: string; }; }>('/users/:user/inbox', { config: { rawBody: true }, bodyLimit: 1024 * 64 }, async (request, reply) => await this.inbox(request, reply));
 
 		// note
 		fastify.get<{ Params: { note: string; } }>('/notes/:note', { constraints: { apOrHtml: 'ap' } }, async (request, reply) => {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fedibirdのサークル、Hubzillaの限定公開タイプのPostの場合、
公開範囲`specified`のアクティビティがそれぞれのユーザーの個別inboxに届く仕様になっているため、
個別のinboxに届いたPostをそのユーザーが見れない場合は`visibleUserIds`を更新し、タイムラインや通知などの処理を行う

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
resolves MisskeyIO#354

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
https://misskey.io/notes/9odvrk1kagpl003v

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
