### PR TITLE
fix(ActivityPub): 個別ユーザーのInboxに届いたPostでノートが作成される場合通知が作成されてしなう問題を修正

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -116,7 +116,7 @@ export class ApNoteService {
 	 * Noteを作成します。
 	 */
 	@bindThis
-	public async createNote(value: string | IObject, resolver?: Resolver, silent = false, additionalTo?: MiLocalUser['id']): Promise<MiNote | null> {
+	public async createNote(value: string | IObject, resolver?: Resolver, silent = false): Promise<MiNote | null> {
 		// eslint-disable-next-line no-param-reassign
 		if (resolver == null) resolver = this.apResolverService.createResolver();
 
@@ -165,13 +165,6 @@ export class ApNoteService {
 		const noteAudience = await this.apAudienceService.parseAudience(actor, note.to, note.cc, resolver);
 		let visibility = noteAudience.visibility;
 		const visibleUsers = noteAudience.visibleUsers;
-
-		if (additionalTo) {
-			const additionalUser = await this.usersRepository.findOneBy({ id: additionalTo, host: IsNull() });
-			if (additionalUser && !visibleUsers.some(x => x.id === additionalUser.id)) {
-				visibleUsers.push(additionalUser);
-			}
-		}
 
 		// Audience (to, cc) が指定されてなかった場合
 		if (visibility === 'specified' && visibleUsers.length === 0) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
個別ユーザーのInboxに届いたPostが初めて受信したノートの場合、
`apNoteService.createNote`の中で直接`visibleUsers`にInboxの持ち主を追加するって実装だったが、
それだとその持ち主にDMとして通知が発生してしまう
ノートを作成し終えてから、既にノートが存在してた場合と同じ処理を走らせるようにした

あと非通知にしてるためToではなくCcに名前を変更

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Mastodonの公開範囲『サークル』と『相互限定』のハンドリング

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
