### PR TITLE
spec(api): Misskey内部の`notifications/create`のレートリミットを廃止

### DIFF
--- a/packages/backend/src/server/api/endpoints/notifications/create.ts
+++ b/packages/backend/src/server/api/endpoints/notifications/create.ts
@@ -14,11 +14,6 @@ export const meta = {
 
 	kind: 'write:notifications',
 
-	limit: {
-		duration: 1000 * 60,
-		max: 10,
-	},
-
 	errors: {
 	},
 } as const;


### PR DESCRIPTION
Cloudflare上でレートリミットをコントロールしたいため