### PR TITLE
fix(backend/logger): `context`の引数を渡すとloggerに設定されたcontextが上書きされてしまう問題を修正

### DIFF
--- a/packages/backend/src/logger.ts
+++ b/packages/backend/src/logger.ts
@@ -13,6 +13,7 @@ import type { KEYWORD } from 'color-convert/conversions.js';
 export default class Logger {
 	private readonly domain: string;
 	private logger: pino.Logger;
+	private context: Record<string, any> = {};
 
 	constructor(domain: string, _color?: KEYWORD, _store = true, parentLogger?: Logger) {
 		if (parentLogger) {
@@ -34,7 +35,7 @@ export default class Logger {
 			formatters: {
 				level: (label, number) => ({ severity: label, level: number }),
 			},
-			mixin: () => ({ cluster: cluster.isPrimary ? 'primary' : `worker#${cluster.worker!.id}` }),
+			mixin: () => ({ cluster: cluster.isPrimary ? 'primary' : `worker#${cluster.worker!.id}`, ...this.context }),
 			transport: !envOption.logJson ? {
 				target: 'pino-pretty',
 				options: {
@@ -57,7 +58,7 @@ export default class Logger {
 
 	@bindThis
 	public setContext(context: Record<string, any>): void {
-		this.logger = this.logger.child({ context });
+		this.context = context;
 	}
 
 	@bindThis


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
