### PR TITLE
fix: 禁止キーワードを含むノートやリモートの通知を引き起こすブロックされた投稿の処理がDelayed Queueに追加されて再処理される問題

### DIFF
--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -24,6 +24,7 @@ import { ApPersonService } from '@/core/activitypub/models/ApPersonService.js';
 import { LdSignatureService } from '@/core/activitypub/LdSignatureService.js';
 import { ApInboxService } from '@/core/activitypub/ApInboxService.js';
 import { bindThis } from '@/decorators.js';
+import { IdentifiableError } from '@/misc/identifiable-error.js';
 import { QueueLoggerService } from '../QueueLoggerService.js';
 import type { InboxJobData } from '../types.js';
 
@@ -180,7 +181,14 @@ export class InboxProcessorService {
 		});
 
 		// アクティビティを処理
-		await this.apInboxService.performActivity(authUser.user, activity, job.data.user?.id);
+		try {
+			await this.apInboxService.performActivity(authUser.user, activity, job.data.user?.id);
+		} catch (e) {
+			if (e instanceof IdentifiableError) {
+				if (e.id === 'e11b3a16-f543-4885-8eb1-66cad131dbfd') return 'blocked mentions from unfamiliar user';
+				if (e.id === '057d8d3e-b7ca-4f8b-b38c-dcdcbf34dc30') return 'blocked notes with prohibited words';
+			}
+		}
 		return 'ok';
 	}
 }

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -188,6 +188,7 @@ export class InboxProcessorService {
 				if (e.id === 'e11b3a16-f543-4885-8eb1-66cad131dbfd') return 'blocked mentions from unfamiliar user';
 				if (e.id === '057d8d3e-b7ca-4f8b-b38c-dcdcbf34dc30') return 'blocked notes with prohibited words';
 			}
+			throw e;
 		}
 		return 'ok';
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

- misskey-dev#13428
- niri-la#153
- niri-la#151

禁止キーワードを含むノートやリモートの通知を引き起こすブロックされた投稿の処理がbullmqによりdelayedに追加される問題を修正しました。

私のサーバーの方でpickさせていただいてましたが、うちの運営がDelayedに追加される問題を見つけてくださったため修正を投げさせていただきました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

無駄に再処理されるため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

misskey-dev#13428 では `ContainsProhibitedWordsError`に相当する`IdentifiableError`のidが`689ee33f-f97c-479a-ac49-1b9f8140af99`ですが、IOは独自に`IdentifiableError`に置き換えていたのでそれに合わせてpickしました。

https://github.com/MisskeyIO/misskey/commit/8f57849d91aad4178ec3161da83892e0cf2a056f#diff-44848fc4891ad8cf42ab0d38e74a0797083d5a76591073745c3c259a43693dbeR273

CHANGELOGは独自にメンテされていないようでしたので更新していません。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
