### PR TITLE
fix(frontend): MFMのグーグル検索ボックスの高さがおかしい問題を修正

### DIFF
--- a/packages/frontend/src/components/MkGoogle.vue
+++ b/packages/frontend/src/components/MkGoogle.vue
@@ -37,11 +37,11 @@ const search = () => {
 	flex-shrink: 1;
 	padding: 10px;
 	width: 100%;
-	height: 40px;
+	height: 18px;
 	font-size: 16px;
 	border: solid 1px var(--divider);
 	border-radius: 4px 0 0 4px;
-	-webkit-appearance: textfield;
+	--webkit-appearance: textfield;
 }
 
 .button {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

https://github.com/MisskeyIO/misskey/pull/482 で高さが変わっちゃった

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
