### PR TITLE
fix(frontend): ノートの詳細ページのユーザーもしくはチャンネルを遡るとタイムラインの並び順番が逆になる問題を修正

### DIFF
--- a/packages/frontend/src/pages/note.vue
+++ b/packages/frontend/src/pages/note.vue
@@ -85,7 +85,6 @@ const prevUserPagination: Paging = {
 };
 
 const nextUserPagination: Paging = {
-	reversed: true,
 	endpoint: 'users/notes',
 	limit: 10,
 	params: computed(() => note.value ? ({
@@ -104,7 +103,6 @@ const prevChannelPagination: Paging = {
 };
 
 const nextChannelPagination: Paging = {
-	reversed: true,
 	endpoint: 'channels/timeline',
 	limit: 10,
 	params: computed(() => note.value ? ({


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
上下逆になっている

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
多分次の投稿・前の投稿のボタンの位置を上下入れ替えた時消し忘れたんじゃないかな

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
cc: @syuilo 

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
