### PR TITLE
enhance(frontend): カスタム絵文字管理画面にてファイル更新で勝手に名前が変わらないように

### DIFF
--- a/packages/frontend/src/pages/emoji-edit-dialog.vue
+++ b/packages/frontend/src/pages/emoji-edit-dialog.vue
@@ -167,7 +167,7 @@ async function changeImage(ev) {
 	file.value = await selectFile(ev.currentTarget ?? ev.target, null);
 	const candidate = file.value.name.replace(/\.(.+)$/, '');
 	if (candidate.match(/^[a-z0-9_]+$/)) {
-		if(!name.value) {
+		if (!name.value) {
 			name.value = candidate;
 		}
 	}

--- a/packages/frontend/src/pages/emoji-edit-dialog.vue
+++ b/packages/frontend/src/pages/emoji-edit-dialog.vue
@@ -165,11 +165,12 @@ const emit = defineEmits<{
 
 async function changeImage(ev) {
 	file.value = await selectFile(ev.currentTarget ?? ev.target, null);
+	if (name.value) {
+		return;
+	}
 	const candidate = file.value.name.replace(/\.(.+)$/, '');
 	if (candidate.match(/^[a-z0-9_]+$/)) {
-		if (!name.value) {
-			name.value = candidate;
-		}
+		name.value = candidate;
 	}
 }
 

--- a/packages/frontend/src/pages/emoji-edit-dialog.vue
+++ b/packages/frontend/src/pages/emoji-edit-dialog.vue
@@ -167,7 +167,9 @@ async function changeImage(ev) {
 	file.value = await selectFile(ev.currentTarget ?? ev.target, null);
 	const candidate = file.value.name.replace(/\.(.+)$/, '');
 	if (candidate.match(/^[a-z0-9_]+$/)) {
-		name.value = candidate;
+		if(!name.value) {
+			name.value = candidate;
+		}
 	}
 }
 

--- a/packages/frontend/src/pages/emoji-edit-dialog.vue
+++ b/packages/frontend/src/pages/emoji-edit-dialog.vue
@@ -165,9 +165,8 @@ const emit = defineEmits<{
 
 async function changeImage(ev) {
 	file.value = await selectFile(ev.currentTarget ?? ev.target, null);
-	if (name.value) {
-		return;
-	}
+	if (name.value) return;
+
 	const candidate = file.value.name.replace(/\.(.+)$/, '');
 	if (candidate.match(/^[a-z0-9_]+$/)) {
 		name.value = candidate;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
カスタム絵文字編集画面にてファイルを上げ直しても名前が書き換わらないようになります。
新しくカスタム絵文字を作成する場合等、名前が空の状態の時のみファイルを上げた時に名前が自動で書き換わるようになります。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
