### PR TITLE
リンクのサムネイルのぼかしを濃くする

### DIFF
--- a/packages/frontend/src/components/MkUrlPreview.vue
+++ b/packages/frontend/src/components/MkUrlPreview.vue
@@ -337,7 +337,7 @@ onUnmounted(() => {
 }
 
 .thumbnailBlur {
-		filter: blur(8px);
+		filter: blur(16px);
 		clip-path: inset(0);
 }
 


### PR DESCRIPTION
8pxだとぼかしを貫通してしまうケースがあったため