### PR TITLE
fix(frontend/ui/navbar): kawaiiモード時のロゴの表示を修正

### DIFF
--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -178,6 +178,7 @@ function more(ev: MouseEvent) {
 	.instanceIconAlt {
 		display: inline-block;
 		width: 85%;
+		max-width: 100%;
 	}
 
 	.bottom {

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -178,7 +178,6 @@ function more(ev: MouseEvent) {
 	.instanceIconAlt {
 		display: inline-block;
 		width: 85%;
-		max-width: 100%;
 	}
 
 	.bottom {
@@ -368,7 +367,8 @@ function more(ev: MouseEvent) {
 	}
 
 	.instanceIconAlt {
-		max-width: 100%;
+		display: inline-block;
+		width: 85%;
 	}
 
 	.bottom {

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -367,6 +367,10 @@ function more(ev: MouseEvent) {
 		aspect-ratio: 1;
 	}
 
+	.instanceIconAlt {
+		max-width: 100%;
+	}
+
 	.bottom {
 		position: sticky;
 		bottom: 0;


### PR DESCRIPTION
## What
kawaiiモード時のロゴの表示問題について修正した

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
