### PR TITLE
feat(frontend): チュートリアルにBotの設定を追加、チュートリアルをスキップ不可に

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -5347,6 +5347,10 @@ export interface Locale extends ILocale {
          * 初期設定をあとでやり直しますか？
          */
         "laterAreYouSure": string;
+        /**
+         * Botアカウントは管理者を必ず記載する必要があります。以下から管理者のアカウントを選択してください。
+         */
+        "mustBeSetBotOwner": string;
     };
     "_initialTutorial": {
         /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1339,6 +1339,7 @@ _initialAccountSetting:
   startTutorial: "チュートリアルを開始"
   skipAreYouSure: "初期設定をスキップしますか？"
   laterAreYouSure: "初期設定をあとでやり直しますか？"
+  mustBeSetBotOwner: "Botアカウントは管理者を必ず記載する必要があります。以下から管理者のアカウントを選択してください。"
 
 _initialTutorial:
   launchTutorial: "チュートリアルを見る"

--- a/packages/frontend/src/components/MkUserSetupDialog.vue
+++ b/packages/frontend/src/components/MkUserSetupDialog.vue
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 	:width="500"
 	:height="550"
 	data-cy-user-setup
-	@close="close(true)"
 	@closed="emit('closed')"
 >
 	<template v-if="page === 1" #header><i class="ti ti-user-edit"></i> {{ i18n.ts._initialAccountSetting.profileSetting }}</template>
@@ -48,12 +47,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<div style="height: 100cqh; overflow: auto;">
 					<div :class="$style.pageRoot">
 						<MkSpacer :marginMin="20" :marginMax="28" :class="$style.pageMain">
-							<XProfile/>
+							<XProfile :onNextButtonEnabled="(state) => page1NextButtonDisabled = !state"/>
 						</MkSpacer>
 						<div :class="$style.pageFooter">
 							<div class="_buttonsCenter">
 								<MkButton rounded data-cy-user-setup-back @click="page--"><i class="ti ti-arrow-left"></i> {{ i18n.ts.goBack }}</MkButton>
-								<MkButton primary rounded gradate data-cy-user-setup-continue @click="page++">{{ i18n.ts.continue }} <i class="ti ti-arrow-right"></i></MkButton>
+								<MkButton primary rounded gradate data-cy-user-setup-continue :disabled="page1NextButtonDisabled" @click="page++">{{ i18n.ts.continue }} <i class="ti ti-arrow-right"></i></MkButton>
 							</div>
 						</div>
 					</div>
@@ -150,6 +149,8 @@ const dialog = shallowRef<InstanceType<typeof MkModalWindow>>();
 
 // eslint-disable-next-line vue/no-setup-props-destructure
 const page = ref(defaultStore.state.accountSetupWizard);
+
+const page1NextButtonDisabled = ref(false);
 
 watch(page, () => {
 	defaultStore.set('accountSetupWizard', page.value);


### PR DESCRIPTION
## What
- アカウント作成後のチュートリアルにBotフラグの設定を追加
  - Bot管理者の設定も可能にした (ユーザー選択後、自己紹介文にテンプレ追記)
- チュートリアルをスキップ不可に (イベントハンドラ解除)
  - 留意事項: なるべくベース部分を改変しない方向で実装したのでダイアログの閉じるボタンは残っている。<br>バグと誤解されないようにするため、やはりMkModalWindowに手を加える必要がある？

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
