### PR TITLE
enhance: 相互リンク機能の連合

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -527,6 +527,25 @@ export class ApRendererService {
 			person['vcard:Address'] = profile.location;
 		}
 
+		if (profile.mutualLinkSections.length > 0) {
+			const ApMutualLinkSections=await Promise.all(profile.mutualLinkSections.map(async section=>{
+				return {
+					sectionName: section.name ? this.mfmService.toHtml(mfm.parse(section.name)) : null,
+					_misskey_sectionName: section.name,
+					entrys: await Promise.all(section.mutualLinks.map(async entry=>{
+						let img=await this.driveFilesRepository.findOneBy({ id: entry.fileId });
+						return {
+							description: entry.description ? this.mfmService.toHtml(mfm.parse(entry.description)) : null,
+							_misskey_description: entry.description,
+							image: img ? this.renderImage(img) : null,
+							url: entry.url,
+						}
+					})),
+				}
+			}));
+			person.mutualLinkSections = ApMutualLinkSections;
+		}
+
 		return person;
 	}
 

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -543,7 +543,7 @@ export class ApRendererService {
 					})),
 				}
 			}));
-			person.mutualLinkSections = ApMutualLinkSections;
+			person.banner = ApMutualLinkSections;
 		}
 
 		return person;

--- a/packages/backend/src/core/activitypub/misc/contexts.ts
+++ b/packages/backend/src/core/activitypub/misc/contexts.ts
@@ -553,6 +553,9 @@ export const CONTEXTS: (string | Context)[] = [
 		'_misskey_votes': 'misskey:_misskey_votes',
 		'_misskey_summary': 'misskey:_misskey_summary',
 		'isCat': 'misskey:isCat',
+		// yojo-art
+		yojoart: 'https://yojoart.kzkr.xyz/ns#',
+		'banner': 'yojoart:banner',
 		// vcard
 		vcard: 'http://www.w3.org/2006/vcard/ns#',
 	} satisfies Context,

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -598,7 +598,7 @@ export class ApPersonService implements OnModuleInit {
 				url: string;
 		}[];
 }[]> {
-		const apMutualLinkSections = person.mutualLinkSections;
+		const apMutualLinkSections = person.banner;
 
 		if (apMutualLinkSections === undefined) return [];
 

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -371,7 +371,6 @@ export class ApPersonService implements OnModuleInit {
 					birthday: bday?.[0] ?? null,
 					location: person['vcard:Address'] ?? null,
 					userHost: host,
-					mutualLinkSections: await this.mutualLinkSections(person, user),
 				}));
 
 				if (person.publicKey) {
@@ -427,6 +426,11 @@ export class ApPersonService implements OnModuleInit {
 			this.logger.error('error occurred while fetching user avatar/banner', { error: err });
 		}
 		//#endregion
+
+		//相互リンク機能の画像をドライブに登録する
+		await this.userProfilesRepository.update({ userId: user.id }, {
+			mutualLinkSections: await this.mutualLinkSections(person, user),
+		});
 
 		await this.updateFeatured(user.id, resolver).catch(err => this.logger.error(err));
 

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -8,7 +8,7 @@ import promiseLimit from 'promise-limit';
 import { DataSource } from 'typeorm';
 import { ModuleRef } from '@nestjs/core';
 import { DI } from '@/di-symbols.js';
-import type { FollowingsRepository, InstancesRepository, UserProfilesRepository, UserPublickeysRepository, UsersRepository } from '@/models/_.js';
+import type { FollowingsRepository, InstancesRepository, MiDriveFile, UserProfilesRepository, UserPublickeysRepository, UsersRepository } from '@/models/_.js';
 import type { Config } from '@/config.js';
 import type { MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import { MiUser } from '@/models/User.js';
@@ -47,7 +47,7 @@ import type { ApNoteService } from './ApNoteService.js';
 import type { ApMfmService } from '../ApMfmService.js';
 import type { ApResolverService, Resolver } from '../ApResolverService.js';
 import type { ApLoggerService } from '../ApLoggerService.js';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+
 import type { ApImageService } from './ApImageService.js';
 import type { IActor, IObject } from '../type.js';
 
@@ -371,6 +371,7 @@ export class ApPersonService implements OnModuleInit {
 					birthday: bday?.[0] ?? null,
 					location: person['vcard:Address'] ?? null,
 					userHost: host,
+					mutualLinkSections: await this.mutualLinkSections(person, user),
 				}));
 
 				if (person.publicKey) {
@@ -547,6 +548,7 @@ export class ApPersonService implements OnModuleInit {
 			description: _description,
 			birthday: bday?.[0] ?? null,
 			location: person['vcard:Address'] ?? null,
+			mutualLinkSections: await this.mutualLinkSections(person, exist),
 		});
 
 		this.globalEventService.publishInternalEvent('remoteUserUpdated', { id: exist.id });
@@ -586,6 +588,48 @@ export class ApPersonService implements OnModuleInit {
 		}
 
 		return 'skip';
+	}
+	async mutualLinkSections(person: IActor, actor: MiRemoteUser) : Promise<[] | {
+		name: string | null;
+		mutualLinks: {
+				fileId: MiDriveFile['id'];
+				description: string | null;
+				imgSrc: string;
+				url: string;
+		}[];
+}[]> {
+		const apMutualLinkSections = person.mutualLinkSections;
+
+		if (apMutualLinkSections === undefined) return [];
+
+		return await Promise.all(apMutualLinkSections.map(async ap => {
+			let name = null;
+			if (ap._misskey_sectionName) {
+				name = truncate(ap._misskey_sectionName, summaryLength);
+			} else if (ap.sectionName) {
+				name = this.apMfmService.htmlToMfm(truncate(ap.sectionName, summaryLength), person.tag);
+			}
+			return {
+				name,
+				mutualLinks: (await Promise.all(ap.entrys.map(async entry => {
+					if (entry.url === null) return null;
+					const image = entry.image ? await this.apImageService.resolveImage(actor, entry.image).catch(() => null) : null;
+					if (image === null) return null;
+					let description = null;
+					if (entry._misskey_description) {
+						description = truncate(entry._misskey_description, summaryLength);
+					} else if (entry.description) {
+						description = this.apMfmService.htmlToMfm(truncate(entry.description, summaryLength), person.tag);
+					}
+					return {
+						fileId: image.id,
+						imgSrc: image.url,
+						url: entry.url,
+						description,
+					};
+				}))).filter(e => e !== null),
+			};
+		}));
 	}
 
 	/**

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -182,6 +182,16 @@ export interface IActor extends IObject {
 	};
 	'vcard:bday'?: string;
 	'vcard:Address'?: string;
+	mutualLinkSections?: {
+		sectionName?: string | null;
+		_misskey_sectionName?: string | null;
+		entrys: {
+				description?: string | null;
+				_misskey_description: string | null;
+				image: string | IObject | null;//ap image
+				url: string | null;//link to
+		}[] | [];
+	}[];
 }
 
 export const isCollection = (object: IObject): object is ICollection =>

--- a/packages/backend/src/core/activitypub/type.ts
+++ b/packages/backend/src/core/activitypub/type.ts
@@ -182,7 +182,7 @@ export interface IActor extends IObject {
 	};
 	'vcard:bday'?: string;
 	'vcard:Address'?: string;
-	mutualLinkSections?: {
+	banner?: {
 		sectionName?: string | null;
 		_misskey_sectionName?: string | null;
 		entrys: {

--- a/packages/backend/src/models/UserProfile.ts
+++ b/packages/backend/src/models/UserProfile.ts
@@ -53,6 +53,7 @@ export class MiUserProfile {
 			fileId: MiDriveFile['id'];
 			description: string | null;
 			imgSrc: string;
+			url: string;
 		}[];
 	}[] | [];
 

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -86,7 +86,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<div :class="$style.mutualLinks">
 								<div v-for="mutualLink in section.mutualLinks.slice(0, $i.policies.mutualLinkLimit)" :key="mutualLink.id">
 									<MkLink :hideIcon="true" :url="mutualLink.url">
-										<img :class="$style.mutualLinkImg" :src="mutualLink.imgSrc" :alt="mutualLink.description"/>
+										<img :class="$style.mutualLinkImg" :src="getProxiedImageUrl(mutualLink.imgSrc)" :alt="mutualLink.description"/>
 									</MkLink>
 								</div>
 							</div>
@@ -98,7 +98,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							<div :class="$style.mutualLinks">
 								<div v-for="mutualLink in section.mutualLinks" :key="mutualLink.id">
 									<MkLink :hideIcon="true" :url="mutualLink.url">
-										<img :class="$style.mutualLinkImg" :src="mutualLink.imgSrc" :alt="mutualLink.description"/>
+										<img :class="$style.mutualLinkImg" :src="getProxiedImageUrl(mutualLink.imgSrc)" :alt="mutualLink.description"/>
 									</MkLink>
 								</div>
 							</div>
@@ -237,6 +237,7 @@ import { confetti } from '@/scripts/confetti.js';
 import { misskeyApi, misskeyApiGet } from '@/scripts/misskey-api.js';
 import { isFollowingVisibleForMe, isFollowersVisibleForMe } from '@/scripts/isFfVisibleForMe.js';
 import { useRouter } from '@/router/supplier.js';
+import { getProxiedImageUrl } from '@/scripts/media-proxy.js';
 import MkLink from '@/components/MkLink.vue';
 import MkContainer from '@/components/MkContainer.vue';
 


### PR DESCRIPTION
## What
相互リンク機能で設定されたカテゴリ名、画像、リンク先、説明文などをユーザーのプロフィールに追加します
私の管理するforkから連合機能の部分をcherrypickしました
https://github.com/yojo-art/cherrypick/pull/319

## Why
独自拡張であっても、必要な場合に受け入れられるように情報を提供するのが最善だと考えます
最初は対応する実装は少ないかもしれませんが、その他の実装であっても必要であれば対応する事ができます

## Additional info (optional)
#702 と関連

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
