### PR TITLE
fix(backend): クリップ周りの不具合修正

### DIFF
--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -134,6 +134,10 @@ export class ClipService {
 			throw new ClipService.NoSuchClipError();
 		}
 
+		if (await this.clipNotesRepository.existsBy({ clipId, noteId })) {
+			throw new ClipService.AlreadyAddedError();
+		}
+
 		const policies = await this.roleService.getUserPolicies(me.id);
 
 		const currentClipCount = await this.clipsRepository.countBy({

--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -147,6 +147,13 @@ export class ClipService {
 			throw new ClipService.ClipLimitExceededError();
 		}
 
+		const currentNoteCount = await this.clipNotesRepository.countBy({
+			clipId: clip.id,
+		});
+		if (currentNoteCount >= policies.noteEachClipsLimit) {
+			throw new ClipService.TooManyClipNotesError();
+		}
+
 		const currentNoteCounts = await this.clipNotesRepository
 			.createQueryBuilder('cn')
 			.select('COUNT(*)')
@@ -156,13 +163,6 @@ export class ClipService {
 			.getRawMany<{ count: number }>();
 		if (currentNoteCounts.some((x) => x.count > policies.noteEachClipsLimit)) {
 			throw new ClipService.ClipNotesLimitExceededError();
-		}
-
-		const currentNoteCount = await this.clipNotesRepository.countBy({
-			clipId: clip.id,
-		});
-		if (currentNoteCount >= policies.noteEachClipsLimit) {
-			throw new ClipService.TooManyClipNotesError();
 		}
 
 		try {

--- a/packages/backend/src/core/UserSuspendService.ts
+++ b/packages/backend/src/core/UserSuspendService.ts
@@ -105,7 +105,7 @@ export class UserSuspendService {
 
 			...promises,
 			this.userListMembershipsRepository.delete({ userId: user.id }),
-		]);
+		]).catch(() => null);
 
 		if (this.userEntityService.isLocalUser(user)) {
 			// 知り得る全SharedInboxにDelete配信

--- a/packages/backend/src/core/UserSuspendService.ts
+++ b/packages/backend/src/core/UserSuspendService.ts
@@ -95,7 +95,7 @@ export class UserSuspendService {
 				.execute());
 		}
 
-		await Promise.all([
+		await Promise.allSettled([
 			this.followRequestsRepository.delete({ followeeId: user.id }),
 			this.followRequestsRepository.delete({ followerId: user.id }),
 
@@ -106,7 +106,7 @@ export class UserSuspendService {
 
 			...promises,
 			this.userListMembershipsRepository.delete({ userId: user.id }),
-		]).catch(() => null);
+		]);
 
 		if (this.userEntityService.isLocalUser(user)) {
 			// 知り得る全SharedInboxにDelete配信

--- a/packages/backend/src/core/UserSuspendService.ts
+++ b/packages/backend/src/core/UserSuspendService.ts
@@ -77,12 +77,13 @@ export class UserSuspendService {
 		let cursor = '';
 		while (true) { // eslint-disable-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
 			const clipNotes = await this.clipNotesRepository.createQueryBuilder('c')
+				.select('c.id')
 				.innerJoin('c.note', 'n')
 				.where('n.userId = :userId', { userId: user.id })
 				.andWhere('c.id > :cursor', { cursor })
 				.orderBy('c.id', 'ASC')
 				.limit(500)
-				.getMany();
+				.getRawMany<{ id: string }>();
 
 			if (clipNotes.length === 0) break;
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- クリップのノート数の上限を超えている際にノートのメニューからクリップ解除できない問題を修正
- TooManyClipNotesError と ClipNotesLimitExceededError の順番を入れ替え
- 凍結されたユーザー自身のアンテナ、ウェブフック、リスト、クリップを消す
- 凍結されたユーザーが含まれているすべてのリストから凍結されてるユーザーを外す
- 凍結されたユーザーのノートをすべてのクリップから消す

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
