### PR TITLE
fix(search): elasticsearchに登録されたノートが削除された場合にunindexされないのを修正

### DIFF
--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -172,6 +172,7 @@ export class SearchService {
 		if (note.text == null && note.cw == null) return;
 		if (!['home', 'public'].includes(note.visibility)) return;
 
+		const createdAt = this.idService.parse(note.id).date;
 		if (this.meilisearch) {
 			switch (this.meilisearchIndexScope) {
 				case 'global':
@@ -190,7 +191,7 @@ export class SearchService {
 
 			await this.meilisearchNoteIndex?.addDocuments([{
 				id: note.id,
-				createdAt: this.idService.parse(note.id).date.getTime(),
+				createdAt: createdAt.getTime(),
 				userId: note.userId,
 				userHost: note.userHost,
 				channelId: note.channelId,
@@ -202,7 +203,7 @@ export class SearchService {
 			});
 		}	else if (this.elasticsearch) {
 			const body = {
-				createdAt: this.idService.parse(note.id).date.getTime(),
+				createdAt: createdAt.getTime(),
 				userId: note.userId,
 				userHost: note.userHost,
 				channelId: note.channelId,
@@ -211,11 +212,11 @@ export class SearchService {
 				tags: note.tags,
 			};
 			await this.elasticsearch.index({
-				index: this.elasticsearchNoteIndex + `-${new Date().toISOString().slice(0, 7).replace(/-/g, '')}` as string,
+				index: this.elasticsearchNoteIndex + `-${createdAt.toISOString().slice(0, 7).replace(/-/g, '')}` as string,
 				id: note.id,
 				body: body,
 			}).catch((error) => {
-				console.error(error);
+				this.logger.error(error);
 			});
 		}
 	}
@@ -226,6 +227,13 @@ export class SearchService {
 
 		if (this.meilisearch) {
 			this.meilisearchNoteIndex!.deleteDocument(note.id);
+		} else if (this.elasticsearch) {
+			await this.elasticsearch.delete({
+				index: this.elasticsearchNoteIndex + `-${this.idService.parse(note.id).date.toISOString().slice(0, 7).replace(/-/g, '')}` as string,
+				id: note.id,
+			}).catch((error) => {
+				this.logger.error(error);
+			});
 		}
 	}
 

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -212,7 +212,7 @@ export class SearchService {
 				tags: note.tags,
 			};
 			await this.elasticsearch.index({
-				index: this.elasticsearchNoteIndex + `-${createdAt.toISOString().slice(0, 7).replace(/-/g, '')}` as string,
+				index: `${this.elasticsearchNoteIndex}-${createdAt.toISOString().slice(0, 7).replace(/-/g, '')}`,
 				id: note.id,
 				body: body,
 			}).catch((error) => {
@@ -229,7 +229,7 @@ export class SearchService {
 			this.meilisearchNoteIndex!.deleteDocument(note.id);
 		} else if (this.elasticsearch) {
 			await this.elasticsearch.delete({
-				index: this.elasticsearchNoteIndex + `-${this.idService.parse(note.id).date.toISOString().slice(0, 7).replace(/-/g, '')}` as string,
+				index: `${this.elasticsearchNoteIndex}-${this.idService.parse(note.id).date.toISOString().slice(0, 7).replace(/-/g, '')}`,
 				id: note.id,
 			}).catch((error) => {
 				this.logger.error(error);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ノートが削除された際にちゃんとelasticsearchのindexを削除するようにした。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
