### PR TITLE
fix(frontend): 絵文字関連のスタイルが崩れていたのを修正

### DIFF
--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -594,7 +594,7 @@ defineExpose({
 						width: auto;
 						height: auto;
 						min-width: 0;
-						padding: 0 3px;
+						padding: 0;
 
 						&:disabled {
 							cursor: not-allowed;
@@ -701,7 +701,7 @@ defineExpose({
 
 				> .item {
 					position: relative;
-					padding: 0;
+					padding: 0 3px;
 					width: var(--eachSize);
 					height: var(--eachSize);
 					contain: strict;

--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -594,6 +594,7 @@ defineExpose({
 						width: auto;
 						height: auto;
 						min-width: 0;
+						padding: 0 3px;
 
 						&:disabled {
 							cursor: not-allowed;

--- a/packages/frontend/src/components/MkNotification.vue
+++ b/packages/frontend/src/components/MkNotification.vue
@@ -46,7 +46,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				:withTooltip="true"
 				:reaction="notification.reaction.replace(/^:(\w+):$/, ':$1@.:')"
 				:noStyle="true"
-				style="width: 100%; height: 100%;"
+				style="width: 100%; height: 100% !important; object-fit: contain;"
 			/>
 		</div>
 	</div>
@@ -123,7 +123,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							:withTooltip="true"
 							:reaction="reaction.reaction.replace(/^:(\w+):$/, ':$1@.:')"
 							:noStyle="true"
-							style="width: 100%; height: 100%;"
+							style="width: 100%; height: 100% !important; object-fit: contain;"
 						/>
 					</div>
 				</div>

--- a/packages/frontend/src/components/MkReactionTooltip.vue
+++ b/packages/frontend/src/components/MkReactionTooltip.vue
@@ -36,6 +36,7 @@ const emit = defineEmits<{
 .icon {
 	display: block;
 	width: 60px;
+	max-height: 60px;
 	font-size: 60px; // unicodeな絵文字についてはwidthが効かないため
 	margin: 0 auto;
 	object-fit: contain;

--- a/packages/frontend/src/components/MkReactionsViewer.details.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.details.vue
@@ -63,6 +63,7 @@ function getReactionName(reaction: string): string {
 .reactionIcon {
 	display: block;
 	width: 60px;
+	max-height: 60px;
 	font-size: 60px; // unicodeな絵文字についてはwidthが効かないため
 	object-fit: contain;
 	margin: 0 auto;

--- a/packages/frontend/src/pages/custom-emojis-manager.vue
+++ b/packages/frontend/src/pages/custom-emojis-manager.vue
@@ -349,6 +349,7 @@ definePageMetadata(() => ({
 				> .img {
 					width: 42px;
 					height: 42px;
+					object-fit: contain;
 				}
 
 				> .body {
@@ -395,6 +396,7 @@ definePageMetadata(() => ({
 				> .img {
 					width: 32px;
 					height: 32px;
+					object-fit: contain;
 				}
 
 				> .body {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

![image](https://github.com/user-attachments/assets/37822adc-7f1d-4aa2-8368-68bf547ad5f2) ![image](https://github.com/user-attachments/assets/7cd8c638-9c1b-4d41-8271-03f2ddc70d30)

MkReactionsViewer.details.vue

![image](https://github.com/user-attachments/assets/dbdb7f6d-748b-4198-a4d1-2f20382df0bf) ![image](https://github.com/user-attachments/assets/f985e7b1-747f-450c-9f76-3ff644d63897)

MkReactionTooltip.vue

![image](https://github.com/user-attachments/assets/d10d6088-5639-4e7b-877d-4651320a5a84) ![image](https://github.com/user-attachments/assets/c6d298ee-6025-42d9-a695-de18bca15b87)

MkNotification.vue

![image](https://github.com/user-attachments/assets/368e3178-211a-4953-aed9-4c64a9e37ab0) ![image](https://github.com/user-attachments/assets/fed83748-1625-472f-9d39-f4d2279467c5)

MkEmojiPicker.vue

![image](https://github.com/user-attachments/assets/66dcf272-09f3-4f69-b297-7fcbb240914c) ![image](https://github.com/user-attachments/assets/6a789aa7-f36d-4622-89f3-ed03c13ec20f)

custom-emojis-manager.vue

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
