### PR TITLE
enhance(backend): 個人宛のお知らせはわかったを押すと過去のお知らせに表示させる

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/announcements/list.ts
+++ b/packages/backend/src/server/api/endpoints/admin/announcements/list.ts
@@ -97,6 +97,11 @@ export const meta = {
 					type: 'number',
 					optional: false, nullable: false,
 				},
+				lastReadAt: {
+					type: 'string',
+					optional: false, nullable: true,
+					format: 'date-time',
+				},
 			},
 		},
 	},
@@ -140,6 +145,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				userId: announcement.userId,
 				user: announcement.userInfo,
 				reads: announcement.reads,
+				lastReadAt: announcement.lastReadAt?.toISOString() ?? null,
 			}));
 		});
 	}

--- a/packages/frontend/src/components/MkUserAnnouncementEditDialog.vue
+++ b/packages/frontend/src/components/MkUserAnnouncementEditDialog.vue
@@ -53,7 +53,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					{{ i18n.ts._announcement.silence }}
 					<template #caption>{{ i18n.ts._announcement.silenceDescription }}</template>
 				</MkSwitch>
-				<p v-if="reads">{{ i18n.tsx.nUsersRead({ n: reads }) }}</p>
+				<p v-if="reads">{{ i18n.tsx.nUsersRead({ n: reads }) }} <span v-if="lastReadAt">(<MkTime :time="lastReadAt" mode="absolute"/>)</span></p>
 				<MkUserCardMini v-if="props.user.id" :user="props.user"></MkUserCardMini>
 				<MkButton v-if="announcement" danger @click="del()"><i class="ti ti-trash"></i> {{ i18n.ts.delete }}</MkButton>
 			</div>
@@ -94,6 +94,7 @@ const closeDuration = ref<number>(props.announcement ? props.announcement.closeD
 const displayOrder = ref<number>(props.announcement ? props.announcement.displayOrder : 0);
 const silence = ref<boolean>(props.announcement ? props.announcement.silence : false);
 const reads = ref<number>(props.announcement ? props.announcement.reads : 0);
+const lastReadAt = ref<string | null>(props.announcement ? props.announcement.lastReadAt : null);
 
 const emit = defineEmits<{
 	(ev: 'done', v: { deleted?: boolean; updated?: any; created?: any }): void,

--- a/packages/frontend/src/pages/admin-user.vue
+++ b/packages/frontend/src/pages/admin-user.vue
@@ -149,7 +149,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 									<i v-else-if="announcement.icon === 'success'" class="ti ti-check" style="color: var(--success);"></i>
 								</span>
 								<span>{{ announcement.title }}</span>
-								<span v-if="announcement.reads > 0" style="margin-left: auto; opacity: 0.7;">{{ i18n.ts.messageRead }}</span>
+								<span v-if="announcement.reads > 0" style="margin-left: auto; opacity: 0.7;">{{ i18n.ts.messageRead }} <span v-if="announcement.lastReadAt">(<MkTime :time="announcement.lastReadAt" mode="absolute"/>)</span></span>
 							</div>
 						</div>
 					</template>

--- a/packages/frontend/src/pages/admin/announcements.vue
+++ b/packages/frontend/src/pages/admin/announcements.vue
@@ -76,7 +76,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkSwitch v-model="announcement.silence" :helpText="i18n.ts._announcement.silenceDescription">
 						{{ i18n.ts._announcement.silence }}
 					</MkSwitch>
-					<p v-if="announcement.reads">{{ i18n.tsx.nUsersRead({ n: announcement.reads }) }}</p>
+					<p v-if="announcement.reads">{{ i18n.tsx.nUsersRead({ n: announcement.reads }) }} <span v-if="announcement.lastReadAt">(<MkTime :time="announcement.lastReadAt" mode="absolute"/>)</span></p>
 					<MkUserCardMini v-if="announcement.userId" :user="announcement.user" @click="editUser(announcement)"></MkUserCardMini>
 					<MkButton v-else class="button" inline primary @click="editUser(announcement)">{{ i18n.ts.specifyUser }}</MkButton>
 					<div class="buttons _buttons">

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -6183,6 +6183,8 @@ export type operations = {
               userId: string | null;
               user: components['schemas']['UserLite'] | null;
               reads: number;
+              /** Format: date-time */
+              lastReadAt: string | null;
             })[];
         };
       };


### PR DESCRIPTION


<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
個人宛のお知らせはわかったを押すと過去のお知らせに表示させる
そしていつ読まれたかがわかるようにする 

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
resolves MisskeyIO#724

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
