### PR TITLE
Fix code scanning alert no. 25: Incomplete URL scheme check

### DIFF
--- a/packages/frontend/src/pages/auth.vue
+++ b/packages/frontend/src/pages/auth.vue
@@ -62,7 +62,7 @@ function accepted() {
 	state.value = 'accepted';
 	if (session.value && session.value.app.callbackUrl) {
 		const url = new URL(session.value.app.callbackUrl);
-		if (['javascript:', 'file:', 'data:', 'mailto:', 'tel:'].includes(url.protocol)) throw new Error('invalid url');
+		if (['javascript:', 'file:', 'data:', 'mailto:', 'tel:', 'vbscript:'].includes(url.protocol)) throw new Error('invalid url');
 		location.href = `${session.value.app.callbackUrl}?token=${session.value.token}`;
 	}
 }

--- a/packages/frontend/src/pages/miauth.vue
+++ b/packages/frontend/src/pages/miauth.vue
@@ -65,7 +65,7 @@ async function onAccept(token: string) {
 
 	if (props.callback && props.callback !== '') {
 		const cbUrl = new URL(props.callback);
-		if (['javascript:', 'file:', 'data:', 'mailto:', 'tel:'].includes(cbUrl.protocol)) throw new Error('invalid url');
+		if (['javascript:', 'file:', 'data:', 'mailto:', 'tel:', 'vbscript:'].includes(cbUrl.protocol)) throw new Error('invalid url');
 		cbUrl.searchParams.set('session', props.session);
 		location.href = cbUrl.toString();
 	} else {


### PR DESCRIPTION
Fixes [https://github.com/MisskeyIO/misskey/security/code-scanning/25](https://github.com/MisskeyIO/misskey/security/code-scanning/25)
Fixes [https://github.com/MisskeyIO/misskey/security/code-scanning/26](https://github.com/MisskeyIO/misskey/security/code-scanning/26)

To fix the problem, we need to extend the URL scheme check to include the `vbscript:` scheme. This involves modifying the conditional statement that checks the URL protocol to also consider `vbscript:` as an invalid scheme. This change should be made in the `onAccept` function where the URL validation occurs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
