### PR TITLE
Fix code scanning alert no. 28: Incomplete string escaping or encoding

### DIFF
--- a/packages/backend/src/misc/sql-like-escape.ts
+++ b/packages/backend/src/misc/sql-like-escape.ts
@@ -4,5 +4,5 @@
  */
 
 export function sqlLikeEscape(s: string) {
-	return s.replace(/([%_])/g, '\\$1');
+	return s.replace(/([\\%_])/g, '\\$1');
 }


### PR DESCRIPTION
Fixes [https://github.com/MisskeyIO/misskey/security/code-scanning/28](https://github.com/MisskeyIO/misskey/security/code-scanning/28)

To fix the problem, we need to modify the `sqlLikeEscape` function to escape backslashes in addition to the existing meta-characters (`%` and `_`). This can be achieved by using a regular expression that matches backslashes and the existing meta-characters, and replacing them with their escaped versions. Specifically, we should replace each backslash with a double backslash and each meta-character with a backslash followed by the character.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
