### PR TITLE
BullMQ + DragonflyDB で Hashtag を使用しすべてをロックしないようにする

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       DFLY_snapshot_cron: '* * * * *'
       DFLY_version_check: false
       DFLY_tcp_backlog: 2048
-      DFLY_default_lua_flags: allow-undeclared-keys
+      DFLY_lock_on_hashtags: true
       DFLY_pipeline_squash: 0
       DFLY_multi_exec_squash: false
       DFLY_conn_io_threads: 4

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           DFLY_version_check: false
           DFLY_tcp_backlog: 2048
-          DFLY_default_lua_flags: allow-undeclared-keys
+          DFLY_lock_on_hashtags: true
           DFLY_pipeline_squash: 0
           DFLY_multi_exec_squash: false
           DFLY_conn_io_threads: 4
@@ -100,7 +100,7 @@ jobs:
         env:
           DFLY_version_check: false
           DFLY_tcp_backlog: 2048
-          DFLY_default_lua_flags: allow-undeclared-keys
+          DFLY_lock_on_hashtags: true
           DFLY_pipeline_squash: 0
           DFLY_multi_exec_squash: false
           DFLY_conn_io_threads: 4

--- a/chart/templates/Deployment.yml
+++ b/chart/templates/Deployment.yml
@@ -44,8 +44,8 @@ spec:
               value: false
             - name: DFLY_tcp_backlog
               value: 2048
-            - name: DFLY_default_lua_flags
-              value: allow-undeclared-keys
+            - name: DFLY_lock_on_hashtags
+              value: true
             - name: DFLY_pipeline_squash
               value: 0
             - name: DFLY_multi_exec_squash

--- a/docker-compose.local-db.yml
+++ b/docker-compose.local-db.yml
@@ -12,7 +12,7 @@ services:
       DFLY_snapshot_cron: '* * * * *'
       DFLY_version_check: false
       DFLY_tcp_backlog: 2048
-      DFLY_default_lua_flags: allow-undeclared-keys
+      DFLY_lock_on_hashtags: true
       DFLY_pipeline_squash: 0
       DFLY_multi_exec_squash: false
       DFLY_conn_io_threads: 4

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -32,7 +32,7 @@ services:
       DFLY_snapshot_cron: '* * * * *'
       DFLY_version_check: false
       DFLY_tcp_backlog: 2048
-      DFLY_default_lua_flags: allow-undeclared-keys
+      DFLY_lock_on_hashtags: true
       DFLY_pipeline_squash: 0
       DFLY_multi_exec_squash: false
       DFLY_conn_io_threads: 4

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -17,6 +17,7 @@ export type RedisOptionsSource = Partial<RedisOptions> & {
 	pass: string;
 	db?: number;
 	prefix?: string;
+	queueNameSuffix?: string;
 };
 
 /**

--- a/packages/backend/src/core/QueueModule.ts
+++ b/packages/backend/src/core/QueueModule.ts
@@ -36,13 +36,13 @@ const $endedPollNotification: Provider = {
 
 const $deliver: Provider = {
 	provide: 'queue:deliver',
-	useFactory: (config: Config) => new Queues(config.redisForDeliverQueues.map(queueConfig => new Bull.Queue(QUEUE.DELIVER, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.DELIVER)))),
+	useFactory: (config: Config) => new Queues(config.redisForDeliverQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.DELIVER}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.DELIVER, index)))),
 	inject: [DI.config],
 };
 
 const $inbox: Provider = {
 	provide: 'queue:inbox',
-	useFactory: (config: Config) => new Queues(config.redisForInboxQueues.map(queueConfig => new Bull.Queue(QUEUE.INBOX, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.INBOX)))),
+	useFactory: (config: Config) => new Queues(config.redisForInboxQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.INBOX}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.INBOX, index)))),
 	inject: [DI.config],
 };
 
@@ -54,7 +54,7 @@ const $db: Provider = {
 
 const $relationship: Provider = {
 	provide: 'queue:relationship',
-	useFactory: (config: Config) => new Queues(config.redisForRelationshipQueues.map(queueConfig => new Bull.Queue(QUEUE.RELATIONSHIP, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.RELATIONSHIP)))),
+	useFactory: (config: Config) => new Queues(config.redisForRelationshipQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.RELATIONSHIP}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.RELATIONSHIP, index)))),
 	inject: [DI.config],
 };
 

--- a/packages/backend/src/core/QueueModule.ts
+++ b/packages/backend/src/core/QueueModule.ts
@@ -6,8 +6,8 @@
 import { Inject, Module, OnApplicationShutdown } from '@nestjs/common';
 import * as Bull from 'bullmq';
 import { DI } from '@/di-symbols.js';
-import type { Config } from '@/config.js';
-import { QUEUE, baseQueueOptions } from '@/queue/const.js';
+import type { Config, RedisOptionsSource } from '@/config.js';
+import { QUEUE, baseQueueOptions, formatQueueName } from '@/queue/const.js';
 import { allSettled } from '@/misc/promise-tracker.js';
 import { Queues } from '@/misc/queues.js';
 import type { Provider } from '@nestjs/common';
@@ -36,13 +36,13 @@ const $endedPollNotification: Provider = {
 
 const $deliver: Provider = {
 	provide: 'queue:deliver',
-	useFactory: (config: Config) => new Queues(config.redisForDeliverQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.DELIVER}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.DELIVER, index)))),
+	useFactory: (config: Config) => createQueues(QUEUE.DELIVER, config.redisForDeliverQueues, config.bullmqQueueOptions),
 	inject: [DI.config],
 };
 
 const $inbox: Provider = {
 	provide: 'queue:inbox',
-	useFactory: (config: Config) => new Queues(config.redisForInboxQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.INBOX}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.INBOX, index)))),
+	useFactory: (config: Config) => createQueues(QUEUE.INBOX, config.redisForInboxQueues, config.bullmqQueueOptions),
 	inject: [DI.config],
 };
 
@@ -54,7 +54,7 @@ const $db: Provider = {
 
 const $relationship: Provider = {
 	provide: 'queue:relationship',
-	useFactory: (config: Config) => new Queues(config.redisForRelationshipQueues.map((queueConfig, index) => new Bull.Queue(`${QUEUE.RELATIONSHIP}-${index}`, baseQueueOptions(queueConfig, config.bullmqQueueOptions, QUEUE.RELATIONSHIP, index)))),
+	useFactory: (config: Config) => createQueues(QUEUE.RELATIONSHIP, config.redisForRelationshipQueues, config.bullmqQueueOptions),
 	inject: [DI.config],
 };
 
@@ -69,6 +69,10 @@ const $webhookDeliver: Provider = {
 	useFactory: (config: Config) => new Bull.Queue(QUEUE.WEBHOOK_DELIVER, baseQueueOptions(config.redisForWebhookDeliverQueue, config.bullmqQueueOptions, QUEUE.WEBHOOK_DELIVER)),
 	inject: [DI.config],
 };
+
+function createQueues(name: typeof QUEUE[keyof typeof QUEUE], config: RedisOptionsSource[], queueOptions: Partial<Bull.QueueOptions>): Queues {
+	return new Queues(config.map(queueConfig => new Bull.Queue(formatQueueName(queueConfig, name), baseQueueOptions(queueConfig, queueOptions, name))));
+}
 
 @Module({
 	imports: [

--- a/packages/backend/src/queue/QueueProcessorService.ts
+++ b/packages/backend/src/queue/QueueProcessorService.ts
@@ -42,7 +42,7 @@ import { CheckExpiredMutingsProcessorService } from './processors/CheckExpiredMu
 import { CleanProcessorService } from './processors/CleanProcessorService.js';
 import { AggregateRetentionProcessorService } from './processors/AggregateRetentionProcessorService.js';
 import { QueueLoggerService } from './QueueLoggerService.js';
-import { QUEUE, baseWorkerOptions } from './const.js';
+import { QUEUE, baseWorkerOptions, formatQueueName } from './const.js';
 
 // ref. https://github.com/misskey-dev/misskey/pull/7635#issue-971097019
 function httpRelatedBackoff(attemptsMade: number) {
@@ -208,8 +208,8 @@ export class QueueProcessorService implements OnApplicationShutdown {
 		//#region deliver
 		this.deliverQueueWorkers = this.config.redisForDeliverQueues
 			.filter((_, index) => process.env.QUEUE_WORKER_INDEX == null || index === Number.parseInt(process.env.QUEUE_WORKER_INDEX, 10))
-			.map((config, index) => new Bull.Worker(`${QUEUE.DELIVER}-${index}`, (job) => this.deliverProcessorService.process(job), {
-				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.DELIVER, index),
+			.map(config => new Bull.Worker(formatQueueName(config, QUEUE.DELIVER), (job) => this.deliverProcessorService.process(job), {
+				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.DELIVER),
 				autorun: false,
 				concurrency: this.config.deliverJobConcurrency ?? 128,
 				limiter: {
@@ -236,8 +236,8 @@ export class QueueProcessorService implements OnApplicationShutdown {
 		//#region inbox
 		this.inboxQueueWorkers = this.config.redisForInboxQueues
 			.filter((_, index) => process.env.QUEUE_WORKER_INDEX == null || index === Number.parseInt(process.env.QUEUE_WORKER_INDEX, 10))
-			.map((config, index) => new Bull.Worker(`${QUEUE.INBOX}-${index}`, (job) => this.inboxProcessorService.process(job), {
-				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.INBOX, index),
+			.map(config => new Bull.Worker(formatQueueName(config, QUEUE.INBOX), (job) => this.inboxProcessorService.process(job), {
+				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.INBOX),
 				autorun: false,
 				concurrency: this.config.inboxJobConcurrency ?? 16,
 				limiter: {
@@ -288,7 +288,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 		//#region relationship
 		this.relationshipQueueWorkers = this.config.redisForRelationshipQueues
 			.filter((_, index) => process.env.QUEUE_WORKER_INDEX == null || index === Number.parseInt(process.env.QUEUE_WORKER_INDEX, 10))
-			.map((config, index) => new Bull.Worker(`${QUEUE.RELATIONSHIP}-${index}`, (job) => {
+			.map(config => new Bull.Worker(formatQueueName(config, QUEUE.RELATIONSHIP), (job) => {
 				switch (job.name) {
 					case 'follow': return this.relationshipProcessorService.processFollow(job);
 					case 'unfollow': return this.relationshipProcessorService.processUnfollow(job);
@@ -297,7 +297,7 @@ export class QueueProcessorService implements OnApplicationShutdown {
 					default: throw new Error(`unrecognized job type ${job.name} for relationship`);
 				}
 			}, {
-				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.RELATIONSHIP, index),
+				...baseWorkerOptions(config, this.config.bullmqWorkerOptions, QUEUE.RELATIONSHIP),
 				autorun: false,
 				concurrency: this.config.relationshipJobConcurrency ?? 16,
 				limiter: {

--- a/packages/backend/src/queue/const.ts
+++ b/packages/backend/src/queue/const.ts
@@ -18,8 +18,12 @@ export const QUEUE = {
 	WEBHOOK_DELIVER: 'webhookDeliver',
 };
 
-export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queueOptions: Partial<Bull.QueueOptions>, queueName: typeof QUEUE[keyof typeof QUEUE], index?: number): Bull.QueueOptions {
-	const name = typeof index === 'number' ? `${queueName}-${index}` : queueName;
+export function formatQueueName(config: RedisOptionsSource, queueName: typeof QUEUE[keyof typeof QUEUE]): string {
+	return typeof config.queueNameSuffix === 'string' ? `${queueName}-${config.queueNameSuffix}` : queueName;
+}
+
+export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queueOptions: Partial<Bull.QueueOptions>, queueName: typeof QUEUE[keyof typeof QUEUE]): Bull.QueueOptions {
+	const name = formatQueueName(config, queueName);
 	return {
 		...queueOptions,
 		connection: {
@@ -38,8 +42,8 @@ export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queu
 	};
 }
 
-export function baseWorkerOptions(config: RedisOptions & RedisOptionsSource, workerOptions: Partial<Bull.WorkerOptions>, queueName: typeof QUEUE[keyof typeof QUEUE], index?: number): Bull.WorkerOptions {
-	const name = typeof index === 'number' ? `${queueName}-${index}` : queueName;
+export function baseWorkerOptions(config: RedisOptions & RedisOptionsSource, workerOptions: Partial<Bull.WorkerOptions>, queueName: typeof QUEUE[keyof typeof QUEUE]): Bull.WorkerOptions {
+	const name = formatQueueName(config, queueName);
 	return {
 		...workerOptions,
 		connection: {

--- a/packages/backend/src/queue/const.ts
+++ b/packages/backend/src/queue/const.ts
@@ -18,7 +18,8 @@ export const QUEUE = {
 	WEBHOOK_DELIVER: 'webhookDeliver',
 };
 
-export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queueOptions: Partial<Bull.QueueOptions>, queueName: typeof QUEUE[keyof typeof QUEUE]): Bull.QueueOptions {
+export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queueOptions: Partial<Bull.QueueOptions>, queueName: typeof QUEUE[keyof typeof QUEUE], index?: number): Bull.QueueOptions {
+	const name = typeof index === 'number' ? `${queueName}-${index}` : queueName;
 	return {
 		...queueOptions,
 		connection: {
@@ -33,11 +34,12 @@ export function baseQueueOptions(config: RedisOptions & RedisOptionsSource, queu
 				return 1;
 			},
 		},
-		prefix: config.prefix ? `${config.prefix}:queue:${queueName}` : `queue:${queueName}`,
+		prefix: config.prefix ? `{${config.prefix}:queue:${name}}` : `{queue:${name}}`,
 	};
 }
 
-export function baseWorkerOptions(config: RedisOptions & RedisOptionsSource, workerOptions: Partial<Bull.WorkerOptions>, queueName: typeof QUEUE[keyof typeof QUEUE]): Bull.WorkerOptions {
+export function baseWorkerOptions(config: RedisOptions & RedisOptionsSource, workerOptions: Partial<Bull.WorkerOptions>, queueName: typeof QUEUE[keyof typeof QUEUE], index?: number): Bull.WorkerOptions {
+	const name = typeof index === 'number' ? `${queueName}-${index}` : queueName;
 	return {
 		...workerOptions,
 		connection: {
@@ -52,6 +54,6 @@ export function baseWorkerOptions(config: RedisOptions & RedisOptionsSource, wor
 				return 1;
 			},
 		},
-		prefix: config.prefix ? `${config.prefix}:queue:${queueName}` : `queue:${queueName}`,
+		prefix: config.prefix ? `{${config.prefix}:queue:${name}}` : `{queue:${name}}`,
 	};
 }

--- a/packages/backend/src/server/web/ClientServerService.ts
+++ b/packages/backend/src/server/web/ClientServerService.ts
@@ -245,13 +245,13 @@ export class ClientServerService {
 			queues: [
 				this.systemQueue,
 				this.endedPollNotificationQueue,
+				...this.deliverQueue.queues,
+				...this.inboxQueue.queues,
 				this.dbQueue,
+				...this.relationshipQueue.queues,
 				this.objectStorageQueue,
 				this.webhookDeliverQueue,
-			].map(q => new BullMQAdapter(q))
-				.concat(this.deliverQueue.queues.map((q, index) => new BullMQAdapter(q, { prefix: `${index}-` })))
-				.concat(this.inboxQueue.queues.map((q, index) => new BullMQAdapter(q, { prefix: `${index}-` })))
-				.concat(this.relationshipQueue.queues.map((q, index) => new BullMQAdapter(q, { prefix: `${index}-` }))),
+			].map(q => new BullMQAdapter(q)),
 			serverAdapter,
 		});
 

--- a/packages/backend/test/docker-compose.yml
+++ b/packages/backend/test/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       DFLY_version_check: false
       DFLY_tcp_backlog: 2048
-      DFLY_default_lua_flags: allow-undeclared-keys
+      DFLY_lock_on_hashtags: true
       DFLY_pipeline_squash: 0
       DFLY_multi_exec_squash: false
       DFLY_conn_io_threads: 4


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
https://www.dragonflydb.io/docs/integrations/bullmq#using-hashtags--optimized-configurations

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
すべてをロックしてほしくないので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Dragonfly の起動フラグに `--lock_on_hashtags` を付ける必要がある。
上記のドキュメントでは `--cluster_mode=emulated` も付けているが、これは https://redirect.github.com/dragonflydb/dragonfly/pull/2443 で1.14.0以降は不要になった

次のリリース後、これだけマージしてリリースしたい

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
