### PR TITLE
feat(timeline): バックグラウンドに行った際、{noteId}.jsonの取得を休止し、復帰した際に直近10件を取得するように

### DIFF
--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -422,6 +422,12 @@ defineExpose({
 	append: appendItem,
 	removeItem,
 	updateItem,
+	stopFetch: () => {
+		more.value = false;
+	},
+	startFetch: () => {
+		more.value = true;
+	},
 });
 </script>
 

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -209,6 +209,10 @@ const reload = (): Promise<void> => {
 	return init();
 };
 
+const deleteItem = () => {
+	items.value = [];
+};
+
 const fetchMore = async (): Promise<void> => {
 	if (!more.value || fetching.value || moreFetching.value || items.value.length === 0) return;
 	moreFetching.value = true;
@@ -414,6 +418,7 @@ defineExpose({
 	more,
 	reload,
 	prepend,
+	deleteItem,
 	append: appendItem,
 	removeItem,
 	updateItem,

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -101,6 +101,12 @@ async function prepend(data) {
 		tlComponent.value.pagingComponent?.prepend(note);
 	} else {
 		if (notVisibleNoteData.has(data.id)) return;
+
+		if (notVisibleNoteData.size > 10) {
+			const firstItem = notVisibleNoteData.values().next().value;
+			if (firstItem) notVisibleNoteData.delete(firstItem);
+		}
+
 		notVisibleNoteData.add(data);
 	}
 
@@ -119,12 +125,15 @@ async function loadUnloadedNotes() {
 	// 10件以上表示できる投稿がない状態でdeleteItemしてしまうと、TLのリロードが入って逆効果になってしまう
 	if (notVisibleNoteData.size > 10) {
 		tlComponent.value.pagingComponent?.deleteItem();
+		tlComponent.value.pagingComponent?.stopFetch();
 	}
 
-	let loopCount = 0;
 	for (const noteData of notVisibleNoteData) {
-		if (loopCount++ > 10) break;
 		await prepend(noteData);
+	}
+
+	if (notVisibleNoteData.size > 10) {
+		tlComponent.value.pagingComponent?.startFetch();
 	}
 
 	notVisibleNoteData.clear();


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- ページネーション表示に、リストの一括削除やデータ取得の一時停止・再開が可能な制御が追加されました。
	- タイムライン表示では、ブラウザの表示状態に合わせてノートの読み込みを自動管理し、非表示時の処理を改善することで、ユーザー体験が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->