### PR TITLE
fix(docker): ビルドに使用した pnpm を runner にコピーする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 WORKDIR /misskey
 
 COPY --link pnpm-lock.yaml ./
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@10 && mkdir -p /root/.local/share/pnpm/.tools
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 	pnpm fetch --ignore-scripts
 
@@ -81,7 +81,7 @@ WORKDIR /misskey
 COPY --chown=misskey:misskey pnpm-lock.yaml ./
 RUN npm install -g pnpm@10
 
-COPY --chown=misskey:misskey --from=target-builder /root/.local/share/pnpm/.tools* ./.local/share/pnpm/.tools
+COPY --chown=misskey:misskey --from=target-builder /root/.local/share/pnpm/.tools ./.local/share/pnpm/.tools
 COPY --chown=misskey:misskey --from=target-builder /misskey/node_modules ./node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/misskey-js/node_modules ./packages/misskey-js/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ WORKDIR /misskey
 COPY --chown=misskey:misskey pnpm-lock.yaml ./
 RUN npm install -g pnpm@10
 
+COPY --chown=misskey:misskey --from=target-builder /root/.local/share/pnpm/.tools ./.local/share/pnpm/.tools
 COPY --chown=misskey:misskey --from=target-builder /misskey/node_modules ./node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/misskey-js/node_modules ./packages/misskey-js/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /misskey
 COPY --chown=misskey:misskey pnpm-lock.yaml ./
 RUN npm install -g pnpm@10
 
-COPY --chown=misskey:misskey --from=target-builder /root/.local/share/pnpm/.tools ./.local/share/pnpm/.tools
+COPY --chown=misskey:misskey --from=target-builder /root/.local/share/pnpm/.tools* ./.local/share/pnpm/.tools
 COPY --chown=misskey:misskey --from=target-builder /misskey/node_modules ./node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
 COPY --chown=misskey:misskey --from=target-builder /misskey/packages/misskey-js/node_modules ./packages/misskey-js/node_modules


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ビルドに使用した pnpm を runner にコピーするようにした

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Dockerfile で指定している `pnpm@10` と package.json の packageManager でバージョンが変わってしまい、MisskeyIO#284 と似た問題が起こるのを防ぐため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - ビルド環境におけるツールの設定を改善し、最終イメージに必要なツールが含まれるようになりました。これにより、環境の整合性と安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->