### PR TITLE
fix(webp): GIFがループしない問題を修正

### DIFF
--- a/packages/backend/src/core/ImageProcessingService.ts
+++ b/packages/backend/src/core/ImageProcessingService.ts
@@ -41,7 +41,6 @@ export const avifDefault: sharp.AvifOptions = {
 	quality: 60,
 	lossless: false,
 	effort: 2,
-	loop: 0,
 };
 
 import { bindThis } from '@/decorators.js';

--- a/packages/backend/src/core/ImageProcessingService.ts
+++ b/packages/backend/src/core/ImageProcessingService.ts
@@ -34,12 +34,14 @@ export const webpDefault: sharp.WebpOptions = {
 	smartSubsample: true,
 	mixed: true,
 	effort: 2,
+	loop: 0,
 };
 
 export const avifDefault: sharp.AvifOptions = {
 	quality: 60,
 	lossless: false,
 	effort: 2,
+	loop: 0,
 };
 
 import { bindThis } from '@/decorators.js';


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

related: https://github.com/MisskeyIO/media-proxy/pull/30

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - WebP画像形式のデフォルト設定に`loop: 0`プロパティが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->