### PR TITLE
build(production): バージョンにGitハッシュを継ぎ足す

### DIFF
--- a/scripts/build-pre.js
+++ b/scripts/build-pre.js
@@ -25,7 +25,7 @@ function removeGitHashSuffix(version) {
 
 function getGitShortHash() {
         try {
-                return execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+                return execSync('git rev-parse --short HEAD', { encoding: 'utf-8', cwd: __dirname }).trim();
         } catch (error) {
                 console.warn('Unable to determine git commit hash:', error);
                 return null;


### PR DESCRIPTION
## Summary
- append the current git short hash to the root and misskey-js package versions during production builds
- keep meta.json in sync with the computed version while preserving existing development behaviour

## Testing
- node scripts/build-pre.js
- NODE_ENV=production node scripts/build-pre.js

------
https://chatgpt.com/codex/tasks/task_e_68ccae45b428832cbd63c6212d335692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  - プロダクションビルド時に短いGitハッシュを付与してバージョン識別が容易に。
  - 複数パッケージ間でバージョンを自動同期し、一貫性を向上。
  - ビルド成果物にバージョン情報を含むメタデータを出力。

* 改善／リファクタリング
  - ビルドフローと監視挙動を整理し、更新検知とログ出力を改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->