### PR TITLE
build(production): Docker ビルドでコミット情報を永続化

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Persist git metadata for Docker build
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$(git rev-parse --short HEAD)" > .git-commit
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Persist git metadata for Docker build
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s\n' "$(git rev-parse --short HEAD)" > .git-commit
       - name: Build an image from Dockerfile
         uses: docker/build-push-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ temp
 /packages/frontend/src/**/*.stories.ts
 tsdoc-metadata.json
 misskey-assets
+.git-commit
 
 # Vite temporary files
 vite.config.js.timestamp-*


### PR DESCRIPTION
## Summary
- persist the current commit hash in CI before invoking Docker builds
- fall back to reading the saved commit hash when .git is unavailable during build-pre
- ignore the generated .git-commit metadata file in the working tree

## Testing
- NODE_ENV=production node scripts/build-pre.js (with .git temporarily moved to verify fallback path)


------
https://chatgpt.com/codex/tasks/task_e_68cdc77a09cc832c953d6d5a5480b29b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - Docker ビルドでコミット情報を永続化し、後続ステップやコンテナイメージにバージョン識別情報を反映できるよう改善。
  - ビルド前処理で Git ハッシュ取得にフォールバックを追加し、.git がない環境でも安定して短縮ハッシュを付与。
  - 生成物のハッシュファイルを無視対象に追加し、リポジトリのクリーンさを維持。

- バグ修正
  - Git 情報が取得できない状況でもビルドが失敗しにくくなるよう安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->