### PR TITLE
fix: リアクションに相乗りする時にも確認ダイアログを表示するように

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -70,11 +70,13 @@ async function toggleReaction() {
 
 	const oldReaction = props.note.myReaction;
 	if (oldReaction) {
-		const confirm = await os.confirm({
-			type: 'warning',
-			text: oldReaction !== props.reaction ? i18n.ts.changeReactionConfirm : i18n.ts.cancelReactionConfirm,
-		});
-		if (confirm.canceled) return;
+		if (prefer.s.confirmOnReact) {
+			const confirm = await os.confirm({
+				type: 'warning',
+				text: oldReaction !== props.reaction ? i18n.ts.changeReactionConfirm : i18n.ts.cancelReactionConfirm,
+			});
+			if (confirm.canceled) return;
+		}
 
 		if (oldReaction !== props.reaction) {
 			sound.playMisskeySfx('reaction');


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
タイムライン上の絵文字をクリックしてリアクションする際、
既存のリアクションがある場合に常に確認ダイアログが表示されていた問題を修正。
`prefer.s.confirmOnReact` 設定が有効な場合のみ確認ダイアログを表示するように変更。

これにより、リアクションピッカーからの選択とタイムライン上の
絵文字クリックの両方で、確認設定が一貫して適用されるようになる。
## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リアクション機能の確認ダイアログ表示を改善しました。ユーザー設定に基づいて、既存のリアクション変更時および新規リアクション追加時に確認ダイアログを表示するかどうかを選択できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->