### PR TITLE
fix: リアクション変更・キャンセル時には常時確認ダイアログが出る挙動が正しいので修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -70,13 +70,11 @@ async function toggleReaction() {
 
 	const oldReaction = props.note.myReaction;
 	if (oldReaction) {
-		if (prefer.s.confirmOnReact) {
-			const confirm = await os.confirm({
-				type: 'warning',
-				text: oldReaction !== props.reaction ? i18n.ts.changeReactionConfirm : i18n.ts.cancelReactionConfirm,
-			});
-			if (confirm.canceled) return;
-		}
+		const confirm = await os.confirm({
+			type: 'warning',
+			text: oldReaction !== props.reaction ? i18n.ts.changeReactionConfirm : i18n.ts.cancelReactionConfirm,
+		});
+		if (confirm.canceled) return;
 
 		if (oldReaction !== props.reaction) {
 			sound.playMisskeySfx('reaction');


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
リアクション変更・キャンセル時には常時確認ダイアログが出る挙動が正しいらしいので修正しました
## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
  * リアクション操作の確認ダイアログ動作を改善しました。既存のリアクションを削除または変更する際、ユーザーの設定に関わらず常に確認ダイアログが表示されるようになり、予期しない変更をより効果的に防止できるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->