### PR TITLE
fix: DBレプリケーションを利用する環境でクエリーが失敗する問題を修正

### DIFF
--- a/packages/backend/src/models/_.ts
+++ b/packages/backend/src/models/_.ts
@@ -5,16 +5,9 @@
 
 import {
 	FindOneOptions,
-	InsertQueryBuilder,
 	ObjectLiteral,
-	QueryRunner,
 	Repository,
-	SelectQueryBuilder,
 } from 'typeorm';
-import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions.js';
-import { RelationCountLoader } from 'typeorm/query-builder/relation-count/RelationCountLoader.js';
-import { RelationIdLoader } from 'typeorm/query-builder/relation-id/RelationIdLoader.js';
-import { RawSqlResultsToEntityTransformer } from 'typeorm/query-builder/transformer/RawSqlResultsToEntityTransformer.js';
 import { MiAbuseReportResolver } from '@/models/AbuseReportResolver.js';
 import { MiAbuseReportNotificationRecipient } from '@/models/AbuseReportNotificationRecipient.js';
 import { MiAbuseUserReport } from '@/models/AbuseUserReport.js';
@@ -97,66 +90,12 @@ import { MiWebhook } from '@/models/Webhook.js';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
 
 export interface MiRepository<T extends ObjectLiteral> {
-	createTableColumnNames(this: Repository<T> & MiRepository<T>): string[];
-
 	insertOne(this: Repository<T> & MiRepository<T>, entity: QueryDeepPartialEntity<T>, findOptions?: Pick<FindOneOptions<T>, 'relations'>): Promise<T>;
-
-	insertOneImpl(this: Repository<T> & MiRepository<T>, entity: QueryDeepPartialEntity<T>, findOptions?: Pick<FindOneOptions<T>, 'relations'>, queryRunner?: QueryRunner): Promise<T>;
-
-	selectAliasColumnNames(this: Repository<T> & MiRepository<T>, queryBuilder: InsertQueryBuilder<T>, builder: SelectQueryBuilder<T>): void;
 }
 
 export const miRepository = {
-	createTableColumnNames() {
-		return this.metadata.columns.filter(column => column.isSelect && !column.isVirtual).map(column => column.databaseName);
-	},
 	async insertOne(entity, findOptions?) {
-		const opt = this.manager.connection.options as PostgresConnectionOptions;
-		if (opt.replication) {
-			const queryRunner = this.manager.connection.createQueryRunner('master');
-			try {
-				return this.insertOneImpl(entity, findOptions, queryRunner);
-			} finally {
-				await queryRunner.release();
-			}
-		} else {
-			return this.insertOneImpl(entity, findOptions);
-		}
-	},
-	async insertOneImpl(entity, findOptions?, queryRunner?) {
-		// ---- insert + returningの結果を共通テーブル式(CTE)に保持するクエリを生成 ----
-
-		const queryBuilder = this.createQueryBuilder().insert().values(entity);
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const mainAlias = queryBuilder.expressionMap.mainAlias!;
-		const name = mainAlias.name;
-		mainAlias.name = 't';
-		const columnNames = this.createTableColumnNames();
-		queryBuilder.returning(columnNames.reduce((a, c) => `${a}, ${queryBuilder.escape(c)}`, '').slice(2));
-
-		// ---- 共通テーブル式(CTE)から結果を取得 ----
-		const builder = this.createQueryBuilder(undefined, queryRunner).addCommonTableExpression(queryBuilder, 'cte', { columnNames });
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		builder.expressionMap.mainAlias!.tablePath = 'cte';
-		this.selectAliasColumnNames(queryBuilder, builder);
-		if (findOptions) {
-			builder.setFindOptions(findOptions);
-		}
-		const raw = await builder.execute();
-		mainAlias.name = name;
-		const relationId = await new RelationIdLoader(builder.connection, this.queryRunner, builder.expressionMap.relationIdAttributes).load(raw);
-		const relationCount = await new RelationCountLoader(builder.connection, this.queryRunner, builder.expressionMap.relationCountAttributes).load(raw);
-		const result = new RawSqlResultsToEntityTransformer(builder.expressionMap, builder.connection.driver, relationId, relationCount, this.queryRunner).transform(raw, mainAlias);
-		return result[0];
-	},
-	selectAliasColumnNames(queryBuilder, builder) {
-		let selectOrAddSelect = (selection: string, selectionAliasName?: string) => {
-			selectOrAddSelect = (selection, selectionAliasName) => builder.addSelect(selection, selectionAliasName);
-			return builder.select(selection, selectionAliasName);
-		};
-		for (const columnName of this.createTableColumnNames()) {
-			selectOrAddSelect(`${builder.alias}.${columnName}`, `${builder.alias}_${columnName}`);
-		}
+		return await this.insert(entity).then(x => this.findOneOrFail({ where: x.identifiers[0], ...findOptions }));
 	},
 } satisfies MiRepository<ObjectLiteral>;
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
起動してしばらく時間（20分）が経つと、削除を含め書き込みの動作のあるAPIのリクエストが高確率で「timeout exceeded when trying to connect」エラーが発生する問題の修正

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
misskey-dev#13908 の変更が原因で、この変更でtypeormの制御外でQueryを実行させることになり、ChartManagementServiceのメモリ情報のDB書き込み動作のsave()が行われる途中のすべてのwrite動作が失敗、その後typeormのコネクションプールが損傷し、コネクションの本来のタイムアウトに達するまで復帰できないという不具合が発生

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
misskey-dev#13908 ははなみすきー等のforkでもrevertされている

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * バックエンドのデータベース操作ロジックを簡素化しました。内部的な複雑な処理フローを最適化し、不要なヘルパーメソッドを削除しました。既存の機能と動作は変わりません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->