### PR TITLE
fix: DockleがDockerHubを参照しようとする問題を回避

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   dockle:
     runs-on: ubuntu-latest
+    if: github.repository == 'MisskeyIO/misskey'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -28,6 +29,12 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s\n' "$(git rev-parse --short HEAD)" > .git-commit
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare image metadata
         shell: bash
         run: |


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ワークフローでイメージメタデータを準備し、ブランチ／タグに応じて BRANCH_NAME を環境変数へ反映するようにしました（タグ名からの抽出対応含む）。
  * ビルドキャッシュをブランチ単位で分離して衝突を回避するようにしました（キャッシュ名にブランチを利用）。
  * セキュリティスキャン実行時の参照イメージをビルド成果物の確定識別子（ダイジェスト）で参照するよう更新しました。
  * GitHub Container Registry へのログインを追加し、ワークフローのリポジトリ条件とパッケージ権限を調整しました。
* 注記: エンドユーザーへの直接的な影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->