### PR TITLE
fix(frontend/emoji): 絵文字パレット設定が正しく反映されるように

### DIFF
--- a/packages/frontend/src/os.ts
+++ b/packages/frontend/src/os.ts
@@ -5,7 +5,7 @@
 
 // TODO: なんでもかんでもos.tsに突っ込むのやめたいのでよしなに分割する
 
-import { defineAsyncComponent, markRaw, nextTick, ref } from 'vue';
+import { computed, defineAsyncComponent, markRaw, nextTick, ref } from 'vue';
 import { EventEmitter } from 'eventemitter3';
 import insertTextAtCursor from 'insert-text-at-cursor';
 import * as Misskey from 'misskey-js';
@@ -710,6 +710,17 @@ export async function openEmojiPicker(src: HTMLElement, opts: ComponentProps<typ
 
 	activeTextarea = initialTextarea;
 
+	const pinnedEmojis = computed(() => {
+		const palettes = prefer.r.emojiPalettes.value;
+		if (palettes.length === 0) return [] as string[];
+		const paletteId = (opts.asReactionPicker ? prefer.r.emojiPaletteForReaction : prefer.r.emojiPaletteForMain).value;
+		const palette = paletteId == null
+			? palettes[0]
+			: palettes.find(p => p.id === paletteId) ?? palettes[0];
+
+		return palette?.emojis ?? [];
+	});
+
 	for (const textarea of Array.from(
 		window.document.querySelectorAll('textarea, input'),
 	)) {
@@ -742,7 +753,7 @@ export async function openEmojiPicker(src: HTMLElement, opts: ComponentProps<typ
 
 	openingEmojiPicker = await popup(MkEmojiPickerWindow, {
 		src,
-		pinnedEmojis: opts.asReactionPicker ? store.r.reactions : store.r.pinnedEmojis,
+		pinnedEmojis,
 		...opts,
 	}, {
 		chosen: emoji => {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 絵文字ピッカーで表示されるピン留め絵文字の選択ロジックを改善しました。ユーザー設定やリアクション機能の状態に基づいて、適切な絵文字パレットが自動的に選択されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->