### PR TITLE
fix(frontend/icon): tabler-iconsをダウングレード・Viteのビルドに巻き込まれないように

### DIFF
--- a/packages/backend/src/server/web/views/base-embed.pug
+++ b/packages/backend/src/server/web/views/base-embed.pug
@@ -19,6 +19,8 @@ html(class='embed')
 		meta(name='format-detection' content='telephone=no,date=no,address=no,email=no,url=no')
 		link(rel='icon' href= icon || '/favicon.ico')
 		link(rel='apple-touch-icon' href= appleTouchIcon || '/apple-touch-icon.png')
+		link(rel='stylesheet' href=`/assets/tabler-icons.${version}/dist/tabler-icons-outline.min.css`)
+		link(rel='stylesheet' href=`/assets/tabler-icons.${version}/dist/tabler-icons-filled.min.css`)
 		link(rel='modulepreload' href=`/embed_vite/${entry.file}`)
 
 		if !config.frontendEmbedManifestExists

--- a/packages/frontend-embed/package.json
+++ b/packages/frontend-embed/package.json
@@ -14,7 +14,6 @@
     "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-replace": "catalog:",
     "@rollup/pluginutils": "catalog:",
-    "@tabler/icons-webfont": "catalog:",
     "@twemoji/parser": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "@vue/compiler-sfc": "catalog:",

--- a/packages/frontend-embed/src/boot.ts
+++ b/packages/frontend-embed/src/boot.ts
@@ -6,8 +6,6 @@
 // https://vitejs.dev/config/build-options.html#build-modulepreload
 import 'vite/modulepreload-polyfill';
 
-import '@tabler/icons-webfont/dist/tabler-icons.scss';
-
 import '@/style.scss';
 import { createApp, defineAsyncComponent } from 'vue';
 import defaultLightTheme from '@@/themes/l-light.json5';

--- a/packages/frontend-embed/vite.config.ts
+++ b/packages/frontend-embed/vite.config.ts
@@ -89,7 +89,7 @@ export function getConfig(): UserConfig {
 				'@/': __dirname + '/src/',
 				'@@/': __dirname + '/../frontend-shared/',
 				'/client-assets/': __dirname + '/assets/',
-				'/static-assets/': __dirname + '/../backend/assets/'
+				'/static-assets/': __dirname + '/../backend/assets/',
 			},
 		},
 

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -34,6 +34,7 @@
     "js-built"
   ],
   "dependencies": {
+    "@tabler/icons-webfont": "catalog:",
     "misskey-js": "workspace:*",
     "vue": "catalog:"
   }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,6 @@
     "@simplewebauthn/browser": "catalog:",
     "@syuilo/aiscript": "catalog:",
     "@syuilo/aiscript-v0": "catalog:",
-    "@tabler/icons-webfont": "catalog:",
     "@twemoji/parser": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "@vue/compiler-core": "catalog:",

--- a/packages/frontend/src/_boot_.ts
+++ b/packages/frontend/src/_boot_.ts
@@ -6,8 +6,6 @@
 // https://vitejs.dev/config/build-options.html#build-modulepreload
 import 'vite/modulepreload-polyfill';
 
-import '@tabler/icons-webfont/dist/tabler-icons.scss';
-
 import '@/style.scss';
 import { mainBoot } from '@/boot/main-boot.js';
 import { subBoot } from '@/boot/sub-boot.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ catalogs:
       specifier: npm:@syuilo/aiscript@~0
       version: 0.19.0
     '@tabler/icons-webfont':
-      specifier: 3.36.0
-      version: 3.36.0
+      specifier: 3.35.0
+      version: 3.35.0
     '@testing-library/vue':
       specifier: 8.1.0
       version: 8.1.0
@@ -1806,9 +1806,6 @@ importers:
       '@syuilo/aiscript-v0':
         specifier: 'catalog:'
         version: '@syuilo/aiscript@0.19.0'
-      '@tabler/icons-webfont':
-        specifier: 'catalog:'
-        version: 3.36.0
       '@twemoji/parser':
         specifier: 'catalog:'
         version: 17.0.1
@@ -2140,9 +2137,6 @@ importers:
       '@rollup/pluginutils':
         specifier: 'catalog:'
         version: 5.3.0(rollup@4.54.0)
-      '@tabler/icons-webfont':
-        specifier: 'catalog:'
-        version: 3.36.0
       '@twemoji/parser':
         specifier: 'catalog:'
         version: 17.0.1
@@ -2294,6 +2288,9 @@ importers:
 
   packages/frontend-shared:
     dependencies:
+      '@tabler/icons-webfont':
+        specifier: 'catalog:'
+        version: 3.35.0
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
@@ -5811,11 +5808,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tabler/icons-webfont@3.36.0':
-    resolution: {integrity: sha512-ZFF6S4ryLq4HKL9VVYLOkEzHyfjippAQhcVXQyz8d5t7pDSA7e+YeI547EEYXU9FgqdvJ7W7zf4LD3zUfLWKIg==}
+  '@tabler/icons-webfont@3.35.0':
+    resolution: {integrity: sha512-PRnv+lgj2Va6S1nTVcZoYDWZPXUaVNromQ9uxn0B1CbBOjqKXAzC/8yLc8XOXD2fH2DWT2XNw1XaNtlNpc0/Tw==}
 
-  '@tabler/icons@3.36.0':
-    resolution: {integrity: sha512-z9OfTEG6QbaQWM9KBOxxUdpgvMUn0atageXyiaSc2gmYm51ORO8Ua7eUcjlks+Dc0YMK4rrodAFdK9SfjJ4ZcA==}
+  '@tabler/icons@3.35.0':
+    resolution: {integrity: sha512-yYXe+gJ56xlZFiXwV9zVoe3FWCGuZ/D7/G4ZIlDtGxSx5CGQK110wrnT29gUj52kEZoxqF7oURTk97GQxELOFQ==}
 
   '@tensorflow/tfjs-backend-cpu@4.22.0':
     resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
@@ -5880,10 +5877,6 @@ packages:
     peerDependenciesMeta:
       '@vue/compiler-sfc':
         optional: true
-
-  '@thednp/dommatrix@2.0.12':
-    resolution: {integrity: sha512-eOshhlSShBXLfrMQqqhA450TppJXhKriaQdN43mmniOCMn9sD60QKF1Axsj7bKl339WH058LuGFS6H84njYH5w==}
-    engines: {node: '>=20', pnpm: '>=8.6.0'}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -11821,10 +11814,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svg-path-commander@2.1.11:
-    resolution: {integrity: sha512-wmQ6QA3Od+HOcpIzLjPlbv59+x3yd3V5W6xitUOvAHmqZpP7wVrRM2CHqEm5viHUbZu6PjzFsjbTEFtIeUxaNA==}
-    engines: {node: '>=16', pnpm: '>=8.6.0'}
-
   svgo@4.0.0:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
@@ -16969,13 +16958,12 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tabler/icons-webfont@3.36.0':
+  '@tabler/icons-webfont@3.35.0':
     dependencies:
-      '@tabler/icons': 3.36.0
+      '@tabler/icons': 3.35.0
       sharp: 0.34.5
-      svg-path-commander: 2.1.11
 
-  '@tabler/icons@3.36.0': {}
+  '@tabler/icons@3.35.0': {}
 
   '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0(encoding@0.1.13))':
     dependencies:
@@ -17086,8 +17074,6 @@ snapshots:
       vue: 3.5.26(typescript@5.9.3)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.26
-
-  '@thednp/dommatrix@2.0.12': {}
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -24052,10 +24038,6 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  svg-path-commander@2.1.11:
-    dependencies:
-      '@thednp/dommatrix': 2.0.12
 
   svgo@4.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,7 @@ catalog:
   '@swc/jest': 0.2.39
   '@syuilo/aiscript': 1.2.1
   '@syuilo/aiscript-v0': npm:@syuilo/aiscript@~0
-  '@tabler/icons-webfont': 3.36.0
+  '@tabler/icons-webfont': 3.35.0
   '@tensorflow/tfjs': 4.22.0
   '@tensorflow/tfjs-core': 4.22.0
   '@tensorflow/tfjs-node': 4.22.0

--- a/scripts/build-assets.mjs
+++ b/scripts/build-assets.mjs
@@ -21,7 +21,7 @@ async function copyFrontendFonts() {
 }
 
 async function copyFrontendTablerIcons() {
-  await fs.cp('./packages/frontend/node_modules/@tabler/icons-webfont', `./built/_frontend_dist_/tabler-icons.${meta.version}`, { dereference: true, recursive: true });
+  await fs.cp('./packages/frontend-shared/node_modules/@tabler/icons-webfont', `./built/_frontend_dist_/tabler-icons.${meta.version}`, { dereference: true, recursive: true });
   for (const file of [
     `./built/_frontend_dist_/tabler-icons.${meta.version}/dist/tabler-icons-filled.scss`,
     `./built/_frontend_dist_/tabler-icons.${meta.version}/dist/tabler-icons-filled.css`,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * アイコンフォントライブラリの依存関係構造を再構成しました。
  * アイコンフォント関連のスタイルシートをHTMLヘッドに統合しました。

* **依存関係の更新**
  * アイコンフォントライブラリをバージョン3.35.0に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->