### PR TITLE
fix(frontend/sensitive-content-consent): モバイル等横幅の狭いデバイスではい・いいえのラベルのレイアウトが崩れる問題を修正(2)

### DIFF
--- a/packages/frontend/src/components/MkSensitiveContentConsent.vue
+++ b/packages/frontend/src/components/MkSensitiveContentConsent.vue
@@ -283,11 +283,8 @@ function submit() {
 	> .before,
 	> .after {
 		transition: all 0.3s ease;
-		flex: 0 1 auto;
-		min-width: 0;
+		flex: 1 1 auto;
 		text-align: center;
-		white-space: nowrap;
-		overflow: hidden;
 		font-weight: bold;
 		font-size: 1.1em;
 		opacity: 0.5;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * センシティブコンテンツ同意トグルのレイアウトを調整し、要素の折り返しと間隔をより応答的に改善しました（テキストの表示や切り詰めが安定）。
  * ラベル周りの柔軟性を見直し、表示の安定性と可読性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->