### PR TITLE
spec(frontend/dimension): デフォルトUIのロールとチャンネルタイムラインに次元の設定ボタンを追加・ノートのヘッダーに次元の表示を追加

### DIFF
--- a/packages/frontend-embed/src/components/EmNoteHeader.vue
+++ b/packages/frontend-embed/src/components/EmNoteHeader.vue
@@ -14,16 +14,20 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<img v-for="(role, i) in note.user.badgeRoles" :key="i" :class="$style.badgeRole" :src="role.iconUrl!"/>
 	</div>
 	<div :class="$style.info">
+		<span v-if="note.dimension" style="opacity: 0.75;">
+			<span>{{ note.dimension }}</span>
+			<i class="ti ti-cube" style="margin-left: 0.25em;"></i>
+		</span>
 		<EmA :to="notePage(note)">
 			<EmTime :time="note.createdAt" colored/>
 		</EmA>
-		<span v-if="note.visibility !== 'public'" style="margin-left: 0.5em;">
+		<span v-if="note.visibility !== 'public'">
 			<i v-if="note.visibility === 'home'" class="ti ti-home"></i>
 			<i v-else-if="note.visibility === 'followers'" class="ti ti-lock"></i>
 			<i v-else-if="note.visibility === 'specified'" ref="specified" class="ti ti-mail"></i>
 		</span>
-		<span v-if="note.localOnly" style="margin-left: 0.5em;"><i class="ti ti-rocket-off"></i></span>
-		<span v-if="note.channel" style="margin-left: 0.5em;" :title="note.channel.name"><i class="ti ti-device-tv"></i></span>
+		<span v-if="note.localOnly"><i class="ti ti-rocket-off"></i></span>
+		<span v-if="note.channel" :title="note.channel.name"><i class="ti ti-device-tv"></i></span>
 	</div>
 </header>
 </template>
@@ -86,6 +90,8 @@ defineProps<{
 .info {
 	flex-shrink: 0;
 	margin-left: auto;
+	display: inline-flex;
+	gap: 0.5em;
 	font-size: 0.9em;
 }
 

--- a/packages/frontend/src/components/MkNoteHeader.vue
+++ b/packages/frontend/src/components/MkNoteHeader.vue
@@ -17,19 +17,23 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<MkRoleBadgeIcon v-for="(role, i) in note.user.badgeRoles" :key="i" v-tooltip="role.name" :userId="note.user.id" :role="role" :class="$style.badgeRole"/>
 	</div>
 	<div :class="$style.info">
+		<span v-if="note.dimension" style="opacity: 0.75;" :title="i18n.tsx.dimensionWithNumber({ dimension: note.dimension })">
+			<span>{{ note.dimension }}</span>
+			<i class="ti ti-cube" style="margin-left: 0.25em;"></i>
+		</span>
 		<div v-if="mock">
 			<MkTime :time="note.createdAt" colored/>
 		</div>
 		<MkA v-else :to="notePage(note)">
 			<MkTime :time="note.createdAt" colored/>
 		</MkA>
-		<span v-if="note.visibility !== 'public'" style="margin-left: 0.5em;" :title="i18n.ts._visibility[note.visibility]">
+		<span v-if="note.visibility !== 'public'" :title="i18n.ts._visibility[note.visibility]">
 			<i v-if="note.visibility === 'home'" class="ti ti-home"></i>
 			<i v-else-if="note.visibility === 'followers'" class="ti ti-lock"></i>
 			<i v-else-if="note.visibility === 'specified'" ref="specified" class="ti ti-mail"></i>
 		</span>
-		<span v-if="note.localOnly" style="margin-left: 0.5em;" :title="i18n.ts._visibility['disableFederation']"><i class="ti ti-rocket-off"></i></span>
-		<span v-if="note.channel" style="margin-left: 0.5em;" :title="note.channel.name"><i class="ti ti-device-tv"></i></span>
+		<span v-if="note.localOnly" :title="i18n.ts._visibility['disableFederation']"><i class="ti ti-rocket-off"></i></span>
+		<span v-if="note.channel" :title="note.channel.name"><i class="ti ti-device-tv"></i></span>
 	</div>
 </header>
 </template>
@@ -93,6 +97,8 @@ const mock = inject(DI.mock, false);
 .info {
 	flex-shrink: 0;
 	margin-left: auto;
+	display: inline-flex;
+	gap: 0.5em;
 	font-size: 0.9em;
 }
 

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -115,7 +115,6 @@ import { store } from '@/store.js';
 import { deepMerge } from '@/utility/merge.js';
 import { selectDimension } from '@/utility/dimension.js';
 import { claimAchievement } from '@/utility/achievements.js';
-import { hasDimension } from '@/timelines.js';
 
 const router = useRouter();
 

--- a/packages/frontend/src/pages/role.vue
+++ b/packages/frontend/src/pages/role.vue
@@ -58,8 +58,6 @@ import { deepMerge } from '@/utility/merge.js';
 import { selectDimension } from '@/utility/dimension.js';
 import { claimAchievement } from '@/utility/achievements.js';
 import { prefer } from '@/preferences.js';
-import { hasDimension } from '@/timelines.js';
-import { deviceKind } from '@/utility/device-kind.js';
 
 const props = withDefaults(defineProps<{
 	roleId: string;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * チャンネル／ロールごとのタイムライン「ディメンション」選択を追加しました（表示方法を保存・復元可能）。
  * 投稿フォームが選択中のディメンションを引き継ぎます。
  * ヘッダーにURLコピー・共有・ディメンション切替アクションを統合しました。

* **UI**
  * ノートヘッダにディメンション表示を追加し、情報行の間隔と配置を調整しました。

* **その他**
  * ディメンション変更でアチーブメントがトリガーされます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->