### PR TITLE
fix(frontend/dimension): 次元の設定ダイアログで最小・最大値の制限が効かない問題を修正・管理画面に次元の設定を追加

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1741,6 +1741,8 @@ _serverSettings:
   manifestJsonOverride: "manifest.json Override"
   shortName: "Short name"
   shortNameDescription: "A shorthand for the instance's name that can be displayed if the full official name is long."
+  dimensions: "Dimension count"
+  dimensionsDescription: "Number of available dimensions. Must be 1 or higher."
   fanoutTimelineDescription: "Greatly increases performance of timeline retrieval and reduces load on the database when enabled. In exchange, memory usage of Redis will increase. Consider disabling this in case of low server memory or server instability."
   fanoutTimelineDbFallback: "Fallback to database"
   fanoutTimelineDbFallbackDescription: "When enabled, the timeline will fall back to the database for additional queries if the timeline is not cached. Disabling it further reduces the server load by eliminating the fallback process, but limits the range of timelines that can be retrieved."
@@ -2863,6 +2865,8 @@ _deck:
 _dialog:
   charactersExceeded: "You've exceeded the maximum character limit! Currently at {current} of {max}."
   charactersBelow: "You're below the minimum character limit! Currently at {current} of {min}."
+  numberBelow: "The value is below the minimum. Currently at {current} of {min}."
+  numberAbove: "The value exceeds the maximum. Currently at {current} of {max}."
 _disabledTimeline:
   title: "Timeline disabled"
   description: "You cannot use this timeline under your current roles."

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -6914,6 +6914,14 @@ export interface Locale extends ILocale {
          */
         "shortNameDescription": string;
         /**
+         * 次元数
+         */
+        "dimensions": string;
+        /**
+         * 利用可能な次元の数。1以上を指定してください。
+         */
+        "dimensionsDescription": string;
+        /**
          * 有効にすると、各種タイムラインを取得する際のパフォーマンスが大幅に向上し、データベースへの負荷を軽減することが可能です。ただし、Redisのメモリ使用量は増加します。サーバーのメモリ容量が少ない場合、または動作が不安定な場合は無効にすることができます。
          */
         "fanoutTimelineDescription": string;
@@ -11143,6 +11151,14 @@ export interface Locale extends ILocale {
          * 最小文字数を下回っています！ 現在 {current} / 制限 {min}
          */
         "charactersBelow": ParameterizedString<"current" | "min">;
+        /**
+         * 最小値を下回っています！ 現在 {current} / 制限 {min}
+         */
+        "numberBelow": ParameterizedString<"current" | "min">;
+        /**
+         * 最大値を超えています！ 現在 {current} / 制限 {max}
+         */
+        "numberAbove": ParameterizedString<"current" | "max">;
     };
     "_disabledTimeline": {
         /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1753,6 +1753,8 @@ _serverSettings:
   manifestJsonOverride: "manifest.jsonのオーバーライド"
   shortName: "略称"
   shortNameDescription: "サーバーの正式名称が長い場合に、代わりに表示することのできる略称や通称。"
+  dimensions: "次元数"
+  dimensionsDescription: "利用可能な次元の数。1以上を指定してください。"
   fanoutTimelineDescription: "有効にすると、各種タイムラインを取得する際のパフォーマンスが大幅に向上し、データベースへの負荷を軽減することが可能です。ただし、Redisのメモリ使用量は増加します。サーバーのメモリ容量が少ない場合、または動作が不安定な場合は無効にすることができます。"
   fanoutTimelineDbFallback: "データベースへのフォールバック"
   fanoutTimelineDbFallbackDescription: "有効にすると、タイムラインがキャッシュされていない場合にDBへ追加で問い合わせを行うフォールバック処理を行います。無効にすると、フォールバック処理を行わないことでさらにサーバーの負荷を軽減することができますが、タイムラインが取得できる範囲に制限が生じます。"
@@ -2933,6 +2935,8 @@ _deck:
 _dialog:
   charactersExceeded: "最大文字数を超えています！ 現在 {current} / 制限 {max}"
   charactersBelow: "最小文字数を下回っています！ 現在 {current} / 制限 {min}"
+  numberBelow: "最小値を下回っています！ 現在 {current} / 制限 {min}"
+  numberAbove: "最大値を超えています！ 現在 {current} / 制限 {max}"
 
 _disabledTimeline:
   title: "無効化されたタイムライン"

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -1733,6 +1733,8 @@ _serverSettings:
   manifestJsonOverride: "manifest.json 오버라이드"
   shortName: "약칭"
   shortNameDescription: "서버의 정식 명칭이 긴 경우에, 대신에 표시할 수 있는 약칭이나 통칭."
+  dimensions: "차원 수"
+  dimensionsDescription: "사용 가능한 차원의 수입니다. 1 이상으로 설정하세요."
   fanoutTimelineDescription: "활성화하면 각종 타임라인을 가져올 때의 성능을 대폭 향상하며, 데이터베이스의 부하를 줄일 수 있습니다. 단, Redis의 메모리 사용량이 증가합니다. 서버의 메모리 용량이 작거나, 서비스가 불안정해지는 경우 비활성화할 수 있습니다."
   fanoutTimelineDbFallback: "데이터베이스를 예비로 사용하기"
   fanoutTimelineDbFallbackDescription: "활성화하면 타임라인의 캐시되어 있지 않은 부분에 대해 DB에 질의하여 정보를 가져옵니다. 비활성화하면 이를 실행하지 않음으로써 서버의 부하를 줄일 수 있지만, 타임라인에서 가져올 수 있는 게시물 범위가 한정됩니다."
@@ -2849,6 +2851,8 @@ _deck:
 _dialog:
   charactersExceeded: "최대 글자수를 초과하였습니다! 현재 {current} / 최대 {max}"
   charactersBelow: "최소 글자수 미만입니다! 현재 {current} / 최소 {min}"
+  numberBelow: "최소값 미만입니다! 현재 {current} / 최소 {min}"
+  numberAbove: "최대값을 초과하였습니다! 현재 {current} / 최대 {max}"
 _disabledTimeline:
   title: "비활성화된 타임라인"
   description: "현재 역할에서는 이 타임라인을 이용할 수 없습니다."

--- a/packages/frontend/src/components/MkDialog.vue
+++ b/packages/frontend/src/components/MkDialog.vue
@@ -33,6 +33,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<template #caption>
 					<span v-if="okButtonDisabledReason === 'charactersExceeded'" v-text="i18n.tsx._dialog.charactersExceeded({ current: (inputValue as string)?.length ?? 0, max: input.maxLength ?? 'NaN' })"/>
 					<span v-else-if="okButtonDisabledReason === 'charactersBelow'" v-text="i18n.tsx._dialog.charactersBelow({ current: (inputValue as string)?.length ?? 0, min: input.minLength ?? 'NaN' })"/>
+					<span v-else-if="okButtonDisabledReason === 'numberBelow'" v-text="i18n.tsx._dialog.numberBelow({ current: inputValue ?? 'NaN', min: input.min ?? 'NaN' })"/>
+					<span v-else-if="okButtonDisabledReason === 'numberAbove'" v-text="i18n.tsx._dialog.numberAbove({ current: inputValue ?? 'NaN', max: input.max ?? 'NaN' })"/>
 				</template>
 			</MkInput>
 			<MkTextarea v-if="input.type === 'textarea'" v-model="inputValue" :placeholder="input.placeholder || undefined" :autocomplete="input.autocomplete">
@@ -40,6 +42,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<template #caption>
 					<span v-if="okButtonDisabledReason === 'charactersExceeded'" v-text="i18n.tsx._dialog.charactersExceeded({ current: (inputValue as string)?.length ?? 0, max: input.maxLength ?? 'NaN' })"/>
 					<span v-else-if="okButtonDisabledReason === 'charactersBelow'" v-text="i18n.tsx._dialog.charactersBelow({ current: (inputValue as string)?.length ?? 0, min: input.minLength ?? 'NaN' })"/>
+					<span v-else-if="okButtonDisabledReason === 'numberBelow'" v-text="i18n.tsx._dialog.numberBelow({ current: inputValue ?? 'NaN', min: input.min ?? 'NaN' })"/>
+					<span v-else-if="okButtonDisabledReason === 'numberAbove'" v-text="i18n.tsx._dialog.numberAbove({ current: inputValue ?? 'NaN', max: input.max ?? 'NaN' })"/>
 				</template>
 			</MkTextarea>
 		</template>
@@ -172,8 +176,26 @@ const okWaitInitiated = computed(() => {
 });
 const okDisabled = computed(() => sec.value > 0);
 
-const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'charactersBelow'>(() => {
+const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'charactersBelow' | 'numberBelow' | 'numberAbove'>(() => {
 	if (props.input) {
+		if (props.input.type === 'number') {
+			const rawValue = inputValue.value;
+			const numericValue = typeof rawValue === 'number'
+				? rawValue
+				: rawValue === '' || rawValue == null
+					? null
+					: Number(rawValue);
+
+			if (numericValue != null && Number.isFinite(numericValue)) {
+				if (props.input.min != null && numericValue < props.input.min) {
+					return 'numberBelow';
+				}
+				if (props.input.max != null && numericValue > props.input.max) {
+					return 'numberAbove';
+				}
+			}
+		}
+
 		if (props.input.minLength) {
 			if (inputValue.value == null || (inputValue.value as string).length < props.input.minLength) {
 				return 'charactersBelow';

--- a/packages/frontend/src/pages/admin/settings.vue
+++ b/packages/frontend/src/pages/admin/settings.vue
@@ -110,6 +110,21 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</MkFolder>
 
 			<MkFolder>
+				<template #icon><i class="ti ti-cube"></i></template>
+				<template #label>{{ i18n.ts.dimension }}</template>
+				<template v-if="dimensionForm.modified.value" #footer>
+					<MkFormFooter :form="dimensionForm"/>
+				</template>
+
+				<div class="_gaps">
+					<MkInput v-model="dimensionForm.state.dimensions" type="number" min="1" step="1">
+						<template #label>{{ i18n.ts._serverSettings.dimensions }}<span v-if="dimensionForm.modifiedStates.dimensions" class="_modified">{{ i18n.ts.modified }}</span></template>
+						<template #caption>{{ i18n.ts._serverSettings.dimensionsDescription }}</template>
+					</MkInput>
+				</div>
+			</MkFolder>
+
+			<MkFolder>
 				<template #icon><i class="ti ti-world-cog"></i></template>
 				<template #label>ServiceWorker</template>
 				<template v-if="serviceWorkerForm.modified.value" #footer>
@@ -303,6 +318,15 @@ const infoForm = useForm({
 		repositoryUrl: state.repositoryUrl,
 		impressumUrl: state.impressumUrl,
 		featuredGameChannels: state.featuredGameChannels.split('\n'),
+	});
+	fetchInstance(true);
+});
+
+const dimensionForm = useForm({
+	dimensions: meta.dimensions,
+}, async (state) => {
+	await os.apiWithDialog('admin/update-meta', {
+		dimensions: state.dimensions,
 	});
 	fetchInstance(true);
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者向けディメンション設定管理機能を追加
  * 数値入力の境界値検証メッセージを追加（最小値未満・最大値超過時のアラート）
  * 日本語および韓国語の多言語対応を拡張

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->