### PR TITLE
fix(frontend): MkDialogがstep属性に対応していなかった問題を修正

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -2867,7 +2867,7 @@ _dialog:
   charactersBelow: "You're below the minimum character limit! Currently at {current} of {min}."
   numberBelow: "The value is below the minimum. Currently at {current} of {min}."
   numberAbove: "The value exceeds the maximum. Currently at {current} of {max}."
-  numberInvalid: "The value is not a valid number. Currently {current}."
+  invalid: "The input is invalid. Currently {current}."
 _disabledTimeline:
   title: "Timeline disabled"
   description: "You cannot use this timeline under your current roles."

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -11160,9 +11160,9 @@ export interface Locale extends ILocale {
          */
         "numberAbove": ParameterizedString<"current" | "max">;
         /**
-         * 無効な数値です！ 現在 {current}
+         * 無効な入力です！ 現在 {current}
          */
-        "numberInvalid": ParameterizedString<"current">;
+        "invalid": ParameterizedString<"current">;
     };
     "_disabledTimeline": {
         /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2937,7 +2937,7 @@ _dialog:
   charactersBelow: "最小文字数を下回っています！ 現在 {current} / 制限 {min}"
   numberBelow: "最小値を下回っています！ 現在 {current} / 制限 {min}"
   numberAbove: "最大値を超えています！ 現在 {current} / 制限 {max}"
-  numberInvalid: "無効な数値です！ 現在 {current}"
+  invalid: "無効な入力です！ 現在 {current}"
 
 _disabledTimeline:
   title: "無効化されたタイムライン"

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -2853,7 +2853,7 @@ _dialog:
   charactersBelow: "최소 글자수 미만입니다! 현재 {current} / 최소 {min}"
   numberBelow: "최소값 미만입니다! 현재 {current} / 최소 {min}"
   numberAbove: "최대값을 초과하였습니다! 현재 {current} / 최대 {max}"
-  numberInvalid: "유효한 숫자가 아닙니다! 현재 {current}"
+  invalid: "유효하지 않은 입력입니다! 현재 {current}"
 _disabledTimeline:
   title: "비활성화된 타임라인"
   description: "현재 역할에서는 이 타임라인을 이용할 수 없습니다."

--- a/packages/frontend/src/components/MkInput.vue
+++ b/packages/frontend/src/components/MkInput.vue
@@ -191,6 +191,7 @@ onUnmounted(() => {
 
 defineExpose({
 	focus,
+	inputEl,
 });
 </script>
 

--- a/packages/frontend/src/components/MkTextarea.vue
+++ b/packages/frontend/src/components/MkTextarea.vue
@@ -144,6 +144,11 @@ onUnmounted(() => {
 		autocompleteWorker.detach();
 	}
 });
+
+defineExpose({
+	focus,
+	inputEl,
+});
 </script>
 
 <style lang="scss" module>

--- a/packages/frontend/src/os.ts
+++ b/packages/frontend/src/os.ts
@@ -9,7 +9,7 @@ import { computed, defineAsyncComponent, markRaw, nextTick, ref } from 'vue';
 import { EventEmitter } from 'eventemitter3';
 import insertTextAtCursor from 'insert-text-at-cursor';
 import * as Misskey from 'misskey-js';
-import type { Component, Ref } from 'vue';
+import type { Component, InputHTMLAttributes, Ref } from 'vue';
 import type { ComponentProps as CP } from 'vue-component-type-helpers';
 import type { Form, GetFormResultType } from '@/utility/form.js';
 import type { MenuItem } from '@/types/menu.js';
@@ -411,6 +411,7 @@ export function inputNumber(props: {
 	default: number;
 	min?: number;
 	max?: number;
+	step?: InputHTMLAttributes['step'];
 }): Promise<{
 	canceled: true; result: undefined;
 } | {
@@ -424,6 +425,7 @@ export function inputNumber(props: {
 	default?: number | null;
 	min?: number;
 	max?: number;
+	step?: InputHTMLAttributes['step'];
 }): Promise<{
 	canceled: true; result: undefined;
 } | {
@@ -437,6 +439,7 @@ export function inputNumber(props: {
 	default?: number | null;
 	min?: number;
 	max?: number;
+	step?: InputHTMLAttributes['step'];
 }): Promise<{
 	canceled: true; result: undefined;
 } | {
@@ -453,6 +456,7 @@ export function inputNumber(props: {
 				default: props.default ?? null,
 				min: props.min,
 				max: props.max,
+				step: props.step,
 			},
 		}, {
 			done: result => {

--- a/packages/frontend/src/utility/dimension.ts
+++ b/packages/frontend/src/utility/dimension.ts
@@ -10,6 +10,7 @@ export async function selectDimension(current?: number | null): Promise<number |
 		default: current ?? prefer.r.dimension.value,
 		min: 0,
 		max,
+		step: 1,
 	});
 	if (canceled || result == null) return undefined;
 	return result;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

closes #1358 
closes #1363

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 数値入力ダイアログにステップ機能を追加。入力値を指定の間隔で増減できるようになりました。

* **改善**
  * 入力エラーメッセージを「無効な数値です」から「無効な入力です」に更新し、より汎用的な表現に変更しました。
  * 入力検証の処理を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->