### PR TITLE
fix(frontend): 入力ダイアログで、数字以外のタイプの場合Validationが意図していないエラーを表示する問題を修正

### DIFF
--- a/packages/frontend/src/components/MkDialog.vue
+++ b/packages/frontend/src/components/MkDialog.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<span v-else-if="okButtonDisabledReason === 'invalid'" v-text="i18n.tsx._dialog.invalid({ current: inputValue ?? 'NaN' })"/>
 				</template>
 			</MkInput>
-			<MkTextarea v-if="input.type === 'textarea'" ref="textareaComponent" v-model="inputValue" :placeholder="input.placeholder || undefined" :autocomplete="input.autocomplete">
+			<MkTextarea v-if="input.type === 'textarea'" v-model="inputValue" :placeholder="input.placeholder || undefined" :autocomplete="input.autocomplete">
 				<template #label>{{ input.placeholder }}</template>
 				<template #caption>
 					<span v-if="okButtonDisabledReason === 'charactersExceeded'" v-text="i18n.tsx._dialog.charactersExceeded({ current: (inputValue as string)?.length ?? 0, max: input.maxLength ?? 'NaN' })"/>
@@ -167,7 +167,6 @@ const emit = defineEmits<{
 
 const modal = useTemplateRef('modal');
 const inputComponent = useTemplateRef<InstanceType<typeof MkInput>>('inputComponent');
-const textareaComponent = useTemplateRef<InstanceType<typeof MkTextarea>>('textareaComponent');
 
 const inputValue = ref<string | number | null>(props.input?.default ?? null);
 const selectedValue = ref(props.select?.default ?? null);
@@ -181,10 +180,6 @@ const okWaitInitiated = computed(() => {
 	return false;
 });
 const okDisabled = computed(() => sec.value > 0);
-
-const inputElement = computed(() => {
-	return inputComponent.value?.inputEl ?? textareaComponent.value?.inputEl ?? null;
-});
 
 const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'charactersBelow' | 'numberBelow' | 'numberAbove' | 'invalid'>(() => {
 	if (props.input) {
@@ -206,6 +201,10 @@ const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'character
 			} else if (numericValue != null) {
 				return 'invalid';
 			}
+
+			if (!inputComponent.value?.inputEl.validity.valid) {
+				return 'invalid';
+			}
 		}
 
 		if (props.input.minLength) {
@@ -217,11 +216,6 @@ const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'character
 			if (inputValue.value && (inputValue.value as string).length > props.input.maxLength) {
 				return 'charactersExceeded';
 			}
-		}
-
-		const inputEl = inputElement.value;
-		if (inputEl && !inputEl.validity.valid) {
-			return 'invalid';
 		}
 	}
 

--- a/packages/frontend/src/components/MkDialog.vue
+++ b/packages/frontend/src/components/MkDialog.vue
@@ -202,7 +202,7 @@ const okButtonDisabledReason = computed<null | 'charactersExceeded' | 'character
 				return 'invalid';
 			}
 
-			if (!inputComponent.value?.inputEl.validity.valid) {
+			if (inputComponent.value && !inputComponent.value.inputEl.validity.valid) {
 				return 'invalid';
 			}
 		}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ダイアログの入力検証ロジックを簡略化しました。
  * 旧来の複合入力サポートを削除して検証処理を統一しました。
  * 数値入力時の有効性判定を改善し、無効状態の判定精度を向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->