### PR TITLE
fix(frontend): AiScriptの機密API呼び出しを制限

### DIFF
--- a/packages/frontend/src/aiscript/api.ts
+++ b/packages/frontend/src/aiscript/api.ts
@@ -5,7 +5,7 @@
 
 import { errors, utils, values } from '@syuilo/aiscript';
 import * as Misskey from 'misskey-js';
-import { url, lang } from '@@/js/config.js';
+import { url, lang, apiUrl } from '@@/js/config.js';
 import { assertStringAndIsIn } from './common.js';
 import * as os from '@/os.js';
 import { misskeyApi } from '@/utility/misskey-api.js';
@@ -76,7 +76,11 @@ export function createAiScriptEnv(opts: { storageKey: string, token?: string }) 
 		}),
 		'Mk:api': values.FN_NATIVE(async ([ep, param, token]) => {
 			utils.assertString(ep);
-			if (ep.value.includes('://') || ep.value.includes('..') || ep.value.startsWith('auth/') || ep.value.startsWith('admin/')) {
+			if (ep.value.includes('://') || ep.value.includes('..')) {
+				throw new errors.AiScriptRuntimeError('invalid endpoint');
+			}
+			const normalizedEndpoint = new URL(`${apiUrl}/${ep.value}`).pathname.slice(new URL(apiUrl).pathname.length + 1);
+			if (normalizedEndpoint.startsWith('auth/') || normalizedEndpoint.startsWith('admin/')) {
 				throw new errors.AiScriptRuntimeError('invalid endpoint');
 			}
 			if (token) {

--- a/packages/frontend/src/aiscript/api.ts
+++ b/packages/frontend/src/aiscript/api.ts
@@ -76,7 +76,7 @@ export function createAiScriptEnv(opts: { storageKey: string, token?: string }) 
 		}),
 		'Mk:api': values.FN_NATIVE(async ([ep, param, token]) => {
 			utils.assertString(ep);
-			if (ep.value.includes('://') || ep.value.includes('..')) {
+			if (ep.value.includes('://') || ep.value.includes('..') || ep.value.startsWith('auth/') || ep.value.startsWith('admin/')) {
 				throw new errors.AiScriptRuntimeError('invalid endpoint');
 			}
 			if (token) {

--- a/packages/frontend/test/aiscript/api.test.ts
+++ b/packages/frontend/test/aiscript/api.test.ts
@@ -339,7 +339,7 @@ describe('AiScript common API', () => {
 
 		test.sequential('invalid auth endpoint', async () => {
 			await expect(exe(`
-				Mk:api('auth/signin', {})
+				Mk:api('auth/accept', {})
 			`)).rejects.toStrictEqual(
 				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
 			);
@@ -348,7 +348,7 @@ describe('AiScript common API', () => {
 
 		test.sequential('invalid relative auth endpoint', async () => {
 			await expect(exe(`
-				Mk:api('./auth/signin', {})
+				Mk:api('./auth/accept', {})
 			`)).rejects.toStrictEqual(
 				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
 			);
@@ -373,20 +373,14 @@ describe('AiScript common API', () => {
 			expect(misskeyApiMock).not.toHaveBeenCalled();
 		});
 
-		test.sequential('allowed endpoint neighbors', async () => {
+		test.sequential('allowed endpoints', async () => {
 			misskeyApiMock.mockImplementation(async endpoint => ({ endpoint }));
 			await exe(`
-				<: Mk:api('authx/signin', {})
 				<: Mk:api('notes/create', {})
 				<: Mk:api('./notes/create', {})
-				<: Mk:api('auth', {})
-				<: Mk:api('admin', {})
 			`);
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(1, 'authx/signin', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(2, 'notes/create', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(3, './notes/create', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(4, 'auth', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(5, 'admin', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(1, 'notes/create', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(2, './notes/create', {}, null, undefined, 'aiscript');
 		});
 
 		test.sequential('missing param', async () => {

--- a/packages/frontend/test/aiscript/api.test.ts
+++ b/packages/frontend/test/aiscript/api.test.ts
@@ -346,9 +346,27 @@ describe('AiScript common API', () => {
 			expect(misskeyApiMock).not.toHaveBeenCalled();
 		});
 
+		test.sequential('invalid relative auth endpoint', async () => {
+			await expect(exe(`
+				Mk:api('./auth/signin', {})
+			`)).rejects.toStrictEqual(
+				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
+			);
+			expect(misskeyApiMock).not.toHaveBeenCalled();
+		});
+
 		test.sequential('invalid admin endpoint', async () => {
 			await expect(exe(`
 				Mk:api('admin/accounts/create', {})
+			`)).rejects.toStrictEqual(
+				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
+			);
+			expect(misskeyApiMock).not.toHaveBeenCalled();
+		});
+
+		test.sequential('invalid relative admin endpoint', async () => {
+			await expect(exe(`
+				Mk:api('./admin/accounts/create', {})
 			`)).rejects.toStrictEqual(
 				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
 			);
@@ -360,13 +378,15 @@ describe('AiScript common API', () => {
 			await exe(`
 				<: Mk:api('authx/signin', {})
 				<: Mk:api('notes/create', {})
+				<: Mk:api('./notes/create', {})
 				<: Mk:api('auth', {})
 				<: Mk:api('admin', {})
 			`);
 			expect(misskeyApiMock).toHaveBeenNthCalledWith(1, 'authx/signin', {}, null, undefined, 'aiscript');
 			expect(misskeyApiMock).toHaveBeenNthCalledWith(2, 'notes/create', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(3, 'auth', {}, null, undefined, 'aiscript');
-			expect(misskeyApiMock).toHaveBeenNthCalledWith(4, 'admin', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(3, './notes/create', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(4, 'auth', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(5, 'admin', {}, null, undefined, 'aiscript');
 		});
 
 		test.sequential('missing param', async () => {

--- a/packages/frontend/test/aiscript/api.test.ts
+++ b/packages/frontend/test/aiscript/api.test.ts
@@ -337,6 +337,38 @@ describe('AiScript common API', () => {
 			expect(misskeyApiMock).not.toHaveBeenCalled();
 		});
 
+		test.sequential('invalid auth endpoint', async () => {
+			await expect(exe(`
+				Mk:api('auth/signin', {})
+			`)).rejects.toStrictEqual(
+				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
+			);
+			expect(misskeyApiMock).not.toHaveBeenCalled();
+		});
+
+		test.sequential('invalid admin endpoint', async () => {
+			await expect(exe(`
+				Mk:api('admin/accounts/create', {})
+			`)).rejects.toStrictEqual(
+				errorWithPos(new errors.AiScriptRuntimeError('invalid endpoint'), 2, 11),
+			);
+			expect(misskeyApiMock).not.toHaveBeenCalled();
+		});
+
+		test.sequential('allowed endpoint neighbors', async () => {
+			misskeyApiMock.mockImplementation(async endpoint => ({ endpoint }));
+			await exe(`
+				<: Mk:api('authx/signin', {})
+				<: Mk:api('notes/create', {})
+				<: Mk:api('auth', {})
+				<: Mk:api('admin', {})
+			`);
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(1, 'authx/signin', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(2, 'notes/create', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(3, 'auth', {}, null, undefined, 'aiscript');
+			expect(misskeyApiMock).toHaveBeenNthCalledWith(4, 'admin', {}, null, undefined, 'aiscript');
+		});
+
 		test.sequential('missing param', async () => {
 			await expect(exe(`
 				Mk:api('ping')


### PR DESCRIPTION
## What

AiScript の `Mk:api` から `auth/` および `admin/` で始まる API を呼び出せないようにします。既存の `invalid endpoint` エラーを返し、リクエストは送信されません。

## Why

AiScript 実行環境から認証・管理者向け API を呼び出せないようにし、権限の強い API へのアクセスを制限します。

## Additional info (optional)

- 実在する `auth/accept`、`admin/accounts/create` と、それらの `./` 表現が拒否されることを回帰テストで確認しました。
- 実在する `notes/create` と `./notes/create` は従来どおり呼び出せることを確認しました。
- `pnpm --filter frontend test` は 131 passed / 4 skipped でした。
- `pnpm --filter frontend typecheck` は既存の変更外エラーにより失敗します。変更した2ファイルの LSP 診断と ESLint は正常です。

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests