### PR TITLE
fix(frontend): トークンがundefined以外の時にフォールバックしないように

### DIFF
--- a/packages/frontend/src/utility/misskey-api.ts
+++ b/packages/frontend/src/utility/misskey-api.ts
@@ -76,7 +76,7 @@ export function misskeyApi<
 	if (endpoint.includes('://')) throw new Error('invalid endpoint');
 	pendingApiRequestsCount.value++;
 
-	const credential = token ? token : $i ? $i.token : undefined;
+	const credential = token !== undefined ? token : $i ? $i.token : undefined;
 
 	const onFinally = () => {
 		pendingApiRequestsCount.value--;


### PR DESCRIPTION
## What
`misskeyApi` に対して`undefined`以外の値がトークンとして渡された場合、デフォルトのトークンにフォールバックしないように変更します

(ref: https://github.com/misskey-dev/misskey/blob/7ab679751357000927558ed00b044f55ce764220/packages/frontend/src/utility/misskey-api.ts#L33-L34)

## Why
現状はfalsyな値が渡された際にデフォルトトークンへのフォールバックが派生するため、`null`を渡した場合においてもトークンが送信されてしまい、意図しない挙動が発生しているため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * API呼び出し時の認証情報選択を改善しました。
  * 認証トークンが未指定の場合のみ、ログイン中ユーザーのトークンを使用します。
  * `null` や空文字列を指定した場合は、その値を明示的に使用します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->